### PR TITLE
Added enrolments check and used UTR check

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/AuthConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/AuthConnector.scala
@@ -23,6 +23,7 @@ import play.api.{Configuration, Logger}
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet}
 import configs.syntax._
+import uk.gov.hmrc.cbcrfrontend.model.Enrolment
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -36,10 +37,10 @@ class AuthConnector @Inject() (httpGet: HttpGet, config:Configuration)(implicit 
     port  <- conf.get[Int]("port")
   } yield s"http://$host:$port").value
 
-  def getEnrolments(implicit hc:HeaderCarrier): Future[JsValue] = for {
+  def getEnrolments(implicit hc:HeaderCarrier): Future[List[Enrolment]] = for {
     authRecord    <- httpGet.GET[JsValue](url + "/auth/authority")
     enrolmentsUri <- Future{(authRecord \ "enrolments").get}
-    enrolments    <- httpGet.GET[JsValue](url + enrolmentsUri.toString().replaceAll("\"",""))
+    enrolments    <- httpGet.GET[List[Enrolment]](url + enrolmentsUri.toString().replaceAll("\"",""))
   } yield enrolments
 
 

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/EnrolController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/EnrolController.scala
@@ -22,15 +22,13 @@ import com.typesafe.config.Config
 import configs.syntax._
 import play.api.Configuration
 import play.api.libs.ws.WSClient
+import play.api.libs.json._
 import uk.gov.hmrc.cbcrfrontend.auth.SecuredActions
 import uk.gov.hmrc.cbcrfrontend.connectors.{AuthConnector, TaxEnrolmentsConnector}
 import uk.gov.hmrc.cbcrfrontend.model.Organisation
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.util.control.NonFatal
-/**
-  * Created by max on 10/05/17.
-  */
 @Singleton
 class EnrolController @Inject()(val sec: SecuredActions, val config:Configuration, ws:WSClient, auth:AuthConnector, enrolConnector: TaxEnrolmentsConnector) extends FrontendController {
 
@@ -51,7 +49,7 @@ class EnrolController @Inject()(val sec: SecuredActions, val config:Configuratio
   }
 
   def getEnrolments = sec.AsyncAuthenticatedAction(){ authContext => implicit request =>
-    auth.getEnrolments.map(Ok(_))
+    auth.getEnrolments.map(e => Ok(Json.toJson(e)))
   }
 
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/Subscription.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/Subscription.scala
@@ -19,10 +19,8 @@ package uk.gov.hmrc.cbcrfrontend.controllers
 
 import javax.inject.{Inject, Singleton}
 
-import cats.data.OptionT
 import cats.data.EitherT
 import cats.instances.all._
-import cats.syntax.all._
 import play.api.Logger
 import play.api.Play._
 import play.api.data.Form
@@ -30,18 +28,18 @@ import play.api.data.Forms._
 import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
 import play.api.i18n.Messages.Implicits._
 import play.api.mvc.{Action, AnyContent, Result}
+import uk.gov.hmrc.cbcrfrontend._
 import uk.gov.hmrc.cbcrfrontend.auth.SecuredActions
-import uk.gov.hmrc.cbcrfrontend.connectors.{BPRKnownFactsConnector, GGConnector}
+import uk.gov.hmrc.cbcrfrontend.connectors.{AuthConnector, BPRKnownFactsConnector}
 import uk.gov.hmrc.cbcrfrontend.exceptions.UnexpectedState
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.services._
 import uk.gov.hmrc.cbcrfrontend.views.html._
 import uk.gov.hmrc.emailaddress.EmailAddress
+import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.frontend.controller.FrontendController
-import uk.gov.hmrc.cbcrfrontend._
-import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
+import uk.gov.hmrc.play.frontend.auth.connectors.{AuthConnector => PlayAuthConnector}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -50,9 +48,10 @@ class Subscription @Inject()(val sec: SecuredActions,
                              val subscriptionDataService: SubscriptionDataService,
                              val connector:BPRKnownFactsConnector,
                              val cbcIdService:CBCIdService,
-                             val kfService:CBCKnownFactsService)
+                             val kfService:CBCKnownFactsService,
+                             val authConnector:AuthConnector)
                             (implicit ec: ExecutionContext,
-                             val authConnector:AuthConnector,
+                             val playAuth:PlayAuthConnector,
                              val session:CBCSessionCache) extends FrontendController with ServicesConfig {
 
 
@@ -76,33 +75,31 @@ class Subscription @Inject()(val sec: SecuredActions,
       subscriptionDataForm.bindFromRequest.fold(
         errors => Future.successful(BadRequest(subscription.contactInfoSubscriber(includes.asideCbc(), includes.phaseBannerBeta(), errors))),
         data => {
-          cbcIdService.getCbcId.flatMap { oId =>
-            oId match {
-              case Some(id) =>
+          cbcIdService.getCbcId.flatMap {
+            case Some(id) =>
 
-                val result = for {
-                  bpr <- EitherT[Future,UnexpectedState,BusinessPartnerRecord](
-                    session.read[BusinessPartnerRecord].map(_.toRight(UnexpectedState("BPR record not found")))
-                  )
-                  utr <- EitherT[Future,UnexpectedState,Utr](
-                    session.read[Utr].map(_.toRight(UnexpectedState("UTR record not found")))
-                  )
-                  _ <- subscriptionDataService.saveSubscriptionData(SubscriptionDetails(bpr, data, id, utr))
-                    _ <- kfService.addKnownFactsToGG(CBCKnownFacts(utr, id))
-                  _ <- EitherT.right[Future,UnexpectedState,CacheMap](session.save(id))
-                  _ <- EitherT.right[Future,UnexpectedState,CacheMap](session.save(data))
-                } yield id
-
-                result.fold(
-                  error => {
-                    subscriptionDataService.clearSubscriptionData(id)
-                    Logger.error(error.errorMsg)
-                    InternalServerError(FrontendGlobal.internalServerErrorTemplate)
-                  },
-                  cbcId => Redirect(routes.Subscription.subscribeSuccessCbcId(cbcId.value))
+              val result = for {
+                bpr <- EitherT[Future, UnexpectedState, BusinessPartnerRecord](
+                  session.read[BusinessPartnerRecord].map(_.toRight(UnexpectedState("BPR record not found")))
                 )
-              case None => Future.successful(InternalServerError(FrontendGlobal.internalServerErrorTemplate))
-            }
+                utr <- EitherT[Future, UnexpectedState, Utr](
+                  session.read[Utr].map(_.toRight(UnexpectedState("UTR record not found")))
+                )
+                _ <- subscriptionDataService.saveSubscriptionData(SubscriptionDetails(bpr, data, id, utr))
+                _ <- kfService.addKnownFactsToGG(CBCKnownFacts(utr, id))
+                _ <- EitherT.right[Future, UnexpectedState, CacheMap](session.save(id))
+                _ <- EitherT.right[Future, UnexpectedState, CacheMap](session.save(data))
+              } yield id
+
+              result.fold(
+                error => {
+                  subscriptionDataService.clearSubscriptionData(id)
+                  Logger.error(error.errorMsg)
+                  InternalServerError(FrontendGlobal.internalServerErrorTemplate)
+                },
+                cbcId => Redirect(routes.Subscription.subscribeSuccessCbcId(cbcId.value))
+              )
+            case None => Future.successful(InternalServerError(FrontendGlobal.internalServerErrorTemplate))
           }
         }
       )
@@ -118,17 +115,22 @@ class Subscription @Inject()(val sec: SecuredActions,
       "utr" -> nonEmptyText.verifying(utrConstraint),
       "postCode" -> nonEmptyText
     )((u,p) => BPRKnownFacts(Utr(u),p))((facts: BPRKnownFacts) => Some(facts.utr.value -> facts.postCode))
-  )
+ )
 
-  val enterKnownFacts = sec.AsyncAuthenticatedAction(){ authContext =>implicit request =>
-    Logger.debug("Country by Country: Subscribe First")
-    getUserType(authContext).map{
-      case Agent => Ok(subscription.enterKnownFacts(includes.asideCbc(), includes.phaseBannerBeta(), knownFactsForm, false, Agent))
-      case Organisation => Ok(subscription.enterKnownFacts(includes.asideCbc(), includes.phaseBannerBeta(), knownFactsForm, noMatchingBusiness = false,Organisation))
-    }.leftMap { errors =>
-      Logger.error(errors.errorMsg)
-      InternalServerError(FrontendGlobal.internalServerErrorTemplate)
-    }.merge
+  val enterKnownFacts = sec.AsyncAuthenticatedAction(){ authContext => implicit request =>
+    authConnector.getEnrolments.flatMap{enrolments =>
+      if(enrolments.exists(_.key == "HMRC-CBC-ORG")) {
+        Future.successful(NotAcceptable(subscription.alreadySubscribed(includes.asideCbc(),includes.phaseBannerBeta())))
+      } else {
+        getUserType(authContext).map{
+          case Agent => Ok(subscription.enterKnownFacts(includes.asideCbc(), includes.phaseBannerBeta(), knownFactsForm, false, Agent))
+          case Organisation => Ok(subscription.enterKnownFacts(includes.asideCbc(), includes.phaseBannerBeta(), knownFactsForm, noMatchingBusiness = false,Organisation))
+        }.leftMap { errors =>
+          Logger.error(errors.errorMsg)
+          InternalServerError(FrontendGlobal.internalServerErrorTemplate)
+        }.merge
+      }
+    }
   }
 
   val checkKnownFacts = sec.AsyncAuthenticatedAction() { authContext =>
@@ -147,6 +149,11 @@ class Subscription @Inject()(val sec: SecuredActions,
             bpr <- knownFactsService.checkBPRKnownFacts(knownFacts).toRight(
               NotFound(subscription.enterKnownFacts(includes.asideCbc(), includes.phaseBannerBeta(), knownFactsForm, noMatchingBusiness = true, userType))
             )
+            alreadySubscribed <- subscriptionDataService.alreadySubscribed(knownFacts.utr).leftMap { error =>
+              Logger.error(error.errorMsg)
+              InternalServerError(FrontendGlobal.internalServerErrorTemplate)
+            }
+            _ <- EitherT.cond[Future](!alreadySubscribed,(), NotAcceptable(subscription.alreadySubscribed(includes.asideCbc(), includes.phaseBannerBeta())))
             _ <- EitherT.right[Future, Result, CacheMap](session.save(bpr))
             _ <- EitherT.right[Future, Result, CacheMap](session.save(knownFacts.utr))
           } yield Ok(subscription.subscribeMatchFound(includes.asideCbc(), includes.phaseBannerBeta(), bpr.organisation.map(_.organisationName).getOrElse(""), knownFacts.postCode, knownFacts.utr.value,userType))

--- a/app/uk/gov/hmrc/cbcrfrontend/model/Enrolments.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/Enrolments.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.model
+
+import play.api.libs.json.Json
+
+
+/**
+  * Created by max on 12/06/17.
+  */
+case class Identifier(key:String,value:String)
+object Identifier{
+  implicit val format = Json.format[Identifier]
+}
+
+case class Enrolment(key:String, identifiers:List[Identifier])
+object Enrolment{
+  implicit val format = Json.format[Enrolment]
+}

--- a/app/uk/gov/hmrc/cbcrfrontend/views/forms/enterCBCId.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/forms/enterCBCId.scala.html
@@ -62,7 +62,7 @@ implicit request: Request[_], messages: Messages)
                     <div class="reminder" style="margin-top:30px">
                         <div class="label">Temporary content - remove for beta</div>
                         <h3 style="padding-left:1em">Don't have a Country by Country ID?</h3>
-                        <a href="/country-by-country-reporting/enterKnownFacts">Register online</a>
+                        <a href="/country-by-country-reporting/register-for-cbcid">Register online</a>
                     </div>
 
 

--- a/app/uk/gov/hmrc/cbcrfrontend/views/subscription/alreadySubscribed.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/subscription/alreadySubscribed.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.play.views.html.helpers._
+@import uk.gov.hmrc.cbcrfrontend.AppConfig
+@import uk.gov.hmrc.cbcrfrontend.views.html._
+@import helper._
+@import tags._
+
+@(asideCbc: Html, phaseBannerBeta: Html)(
+implicit request: Request[_], messages: Messages)
+
+@sidebarContent = {
+@asideCbc
+}
+
+@main_template("Country by Country Reporting", sidebarLinks = Some(sidebarContent)) {
+<div class="grid-row">
+    <div class="column-two-thirds">
+        <h1>
+            Register for Country by Country reporting
+        </h1>
+
+        <div class="flash error-summary error-summary--show"
+             id="error-summary-display"
+             role="alert"
+             aria-labelledby="error-summary-heading"
+             tabindex="-1">
+            <p>This multinational enterprise has already been registered.  </p>
+            <p>If this isn't correct, <a href="contact-hmrc-dummy-page">contact HMRC.</a></p>
+
+        </div>
+
+        <a class="button" href="service-landing-page">Sign out</a>
+    </div>
+</div>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -15,6 +15,7 @@ GET        /get-business-rule-errors                      @uk.gov.hmrc.cbcrfront
 GET        /get-xml-schema-errors                         @uk.gov.hmrc.cbcrfrontend.controllers.FileUpload.getXmlSchemaErrors
 
 GET        /filingType                                    @uk.gov.hmrc.cbcrfrontend.controllers.Submission.filingType
+GET        /known-facts-check                             @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.enterKnownFacts
 POST       /submitFilingType                              @uk.gov.hmrc.cbcrfrontend.controllers.Submission.submitFilingType
 POST       /submitUltimateParentEntity                    @uk.gov.hmrc.cbcrfrontend.controllers.Submission.submitUltimateParentEntity
 POST       /submitFilingCapacity                          @uk.gov.hmrc.cbcrfrontend.controllers.Submission.submitFilingCapacity
@@ -25,7 +26,7 @@ GET        /filingHistory                                 @uk.gov.hmrc.cbcrfront
 POST       /confirm                                       @uk.gov.hmrc.cbcrfrontend.controllers.Submission.confirm
 
 POST       /checkKnownFacts                               @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.checkKnownFacts
-GET        /enterKnownFacts                               @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.enterKnownFacts
+GET        /register-for-cbcid                            @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.enterKnownFacts
 GET        /contactInfoSubscriber                         @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.contactInfoSubscriber
 GET        /subscribeSuccessCbcId/:cbcId                  @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.subscribeSuccessCbcId(cbcId:String)
 POST       /submitSubscriptionData                        @uk.gov.hmrc.cbcrfrontend.controllers.Subscription.submitSubscriptionData

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/FakeAuthConnector.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/FakeAuthConnector.scala
@@ -18,13 +18,18 @@ package uk.gov.hmrc.cbcrfrontend.controllers
 
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
-import uk.gov.hmrc.play.http.HttpGet
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpReads, HttpResponse}
+
+import scala.concurrent.Future
 
 
 trait FakeAuthConnector {
   def authConnector(user: AuthContext): AuthConnector = new AuthConnector {
     def http: HttpGet = ???
     val serviceUrl: String = "test-service-url"
+
+    override def getEnrolments[T](authContext: AuthContext)(implicit hc: HeaderCarrier, reads: HttpReads[T]): Future[T] =
+      Future.successful(reads.read("yeah","something",HttpResponse(200)))
 
   }
 }

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionSpec.scala
@@ -37,10 +37,10 @@ import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import cats.instances.future._
 import org.mockito.Matchers
 import org.mockito.Matchers.{eq => EQ}
-import uk.gov.hmrc.cbcrfrontend.connectors.BPRKnownFactsConnector
+import uk.gov.hmrc.cbcrfrontend.connectors.{AuthConnector, BPRKnownFactsConnector}
 import uk.gov.hmrc.http.cache.client.CacheMap
-import scala.reflect.runtime.universe._
 
+import scala.reflect.runtime.universe._
 import scala.concurrent.{ExecutionContext, Future}
 
 class SubscriptionSpec extends UnitSpec with ScalaFutures with OneAppPerSuite with CSRFTest with MockitoSugar with FakeAuthConnector {
@@ -54,10 +54,11 @@ class SubscriptionSpec extends UnitSpec with ScalaFutures with OneAppPerSuite wi
   val dc = mock[BPRKnownFactsConnector]
   val cbcId = mock[CBCIdService]
   val cbcKF = mock[CBCKnownFactsService]
+  val auth  = mock[AuthConnector]
   implicit val cache = mock[CBCSessionCache]
   when(cache.read[AffinityGroup](any(),any(),any())) thenReturn Future.successful(Some(AffinityGroup("Organisation")))
 
-  val controller = new Subscription(securedActions, subService,dc,cbcId,cbcKF)
+  val controller = new Subscription(securedActions, subService,dc,cbcId,cbcKF,auth)
 
   implicit val hc = HeaderCarrier()
   implicit val cbcrsUrl = new ServiceUrl[CbcrsUrl] { val url = "cbcr"}
@@ -66,9 +67,16 @@ class SubscriptionSpec extends UnitSpec with ScalaFutures with OneAppPerSuite wi
   implicit val utrTag = implicitly[TypeTag[Utr]]
 
 
- "GET /enterKnownFacts" should {
-    "return 200" in {
-      val fakeRequestSubscribe = addToken(FakeRequest("GET", "/enterKnownFacts"))
+ "GET /known-facts-check" should {
+   "return 406 if we have already subscribed" in {
+     when(auth.getEnrolments(any())) thenReturn List(Enrolment("HMRC-CBC-ORG",List.empty))
+     val fakeRequestSubscribe = addToken(FakeRequest("GET", "/known-facts-check"))
+     status(controller.enterKnownFacts(fakeRequestSubscribe)) shouldBe Status.NOT_ACCEPTABLE
+
+   }
+    "return 200 if we havent already subscribed" in {
+      when(auth.getEnrolments(any())) thenReturn List.empty
+      val fakeRequestSubscribe = addToken(FakeRequest("GET", "/known-facts-check"))
       status(controller.enterKnownFacts(fakeRequestSubscribe)) shouldBe Status.OK
     }
   }
@@ -99,6 +107,17 @@ class SubscriptionSpec extends UnitSpec with ScalaFutures with OneAppPerSuite wi
       when(dc.lookup(anyObject[String])(anyObject[HeaderCarrier])) thenReturn Future.successful(HttpResponse(Status.OK, Some(Json.toJson(response))))
       status(controller.checkKnownFacts(fakeRequestSubscribe)) shouldBe Status.NOT_FOUND
     }
+    "return 406 when we have already used that utr"  in {
+      val kf = BPRKnownFacts(Utr("7000000002"), "SW46NR")
+      val response = BusinessPartnerRecord("safeid", Some(OrganisationResponse("My Corp")), EtmpAddress(None, None, None, None, Some("SW46NR"), None))
+      val fakeRequestSubscribe = addToken(FakeRequest("POST", "/checkKnownFacts").withJsonBody(Json.toJson(kf)))
+      when(dc.lookup(anyObject[String])(anyObject[HeaderCarrier])) thenReturn Future.successful(HttpResponse(Status.OK, Some(Json.toJson(response))))
+      when(cache.save[BusinessPartnerRecord](any())(any(),any(),any())) thenReturn Future.successful(CacheMap("cache", Map.empty[String,JsValue]))
+      when(cache.save[Utr](any())(any(),any(),any())) thenReturn Future.successful(CacheMap("cache", Map.empty[String,JsValue]))
+      when(subService.alreadySubscribed(any())(any(),any())) thenReturn EitherT.pure[Future,UnexpectedState,Boolean](true)
+      status(controller.checkKnownFacts(fakeRequestSubscribe)) shouldBe Status.NOT_ACCEPTABLE
+
+    }
     "return 200 when the utr and postcode are valid" in {
       val kf = BPRKnownFacts(Utr("7000000002"), "SW46NR")
       val response = BusinessPartnerRecord("safeid", Some(OrganisationResponse("My Corp")), EtmpAddress(None, None, None, None, Some("SW46NR"), None))
@@ -106,6 +125,7 @@ class SubscriptionSpec extends UnitSpec with ScalaFutures with OneAppPerSuite wi
       when(dc.lookup(anyObject[String])(anyObject[HeaderCarrier])) thenReturn Future.successful(HttpResponse(Status.OK, Some(Json.toJson(response))))
       when(cache.save[BusinessPartnerRecord](any())(any(),any(),any())) thenReturn Future.successful(CacheMap("cache", Map.empty[String,JsValue]))
       when(cache.save[Utr](any())(any(),any(),any())) thenReturn Future.successful(CacheMap("cache", Map.empty[String,JsValue]))
+      when(subService.alreadySubscribed(any())(any(),any())) thenReturn EitherT.pure[Future,UnexpectedState,Boolean](false)
       status(controller.checkKnownFacts(fakeRequestSubscribe)) shouldBe Status.OK
     }
   }


### PR DESCRIPTION
On starting the subscription journey - we check to see if a HMRC-CBC-ORG key exists in their enrolments. If it does, it redirects them to the error page.

Also, after the known facts portion of the subscription journey - it checks if we have already used that UTR to subscribe. If we have, it redirects to the error page.