### PR TITLE
Feature/cbcr 239

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/EnrolmentsConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/EnrolmentsConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcrfrontend.connectors
 import javax.inject.Inject
 
 import com.typesafe.config.Config
-import play.api.{Configuration, Logger}
+import play.api.Configuration
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet}
 import configs.syntax._
@@ -28,7 +28,7 @@ import uk.gov.hmrc.cbcrfrontend.model.Enrolment
 import scala.concurrent.{ExecutionContext, Future}
 
 
-class AuthConnector @Inject() (httpGet: HttpGet, config:Configuration)(implicit ec:ExecutionContext) {
+class EnrolmentsConnector @Inject() (httpGet: HttpGet, config:Configuration)(implicit ec:ExecutionContext) {
 
   val conf = config.underlying.get[Config]("microservice.services.auth").value
 

--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnector.scala
@@ -62,7 +62,7 @@ class FileUploadServiceConnector() {
   def extractFileUploadMessage(resp: HttpResponse): CBCErrorOr[String] = {
       resp.status match {
         case 200 => Right(resp.body)
-        case _ => Left(UnexpectedState("Problems uploading the file"))
+        case   _ => Left(UnexpectedState("Problems uploading the file"))
       }
   }
 

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/CBCController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/CBCController.scala
@@ -21,16 +21,14 @@ import javax.inject.{Inject, Singleton}
 import cats.data.OptionT
 import cats.instances.all._
 import cats.syntax.all._
-import play.api.Logger
 import play.api.Play.current
 import play.api.data.Form
 import play.api.data.Forms._
 import play.api.i18n.Messages.Implicits._
-import play.api.mvc.{Action, Request, Result}
+import play.api.mvc.{Action, Result}
 import uk.gov.hmrc.cbcrfrontend._
 import uk.gov.hmrc.cbcrfrontend.auth.SecuredActions
 import uk.gov.hmrc.cbcrfrontend.connectors.EnrolmentsConnector
-import uk.gov.hmrc.cbcrfrontend.exceptions.CBCErrors
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.services.{CBCSessionCache, SubscriptionDataService}
 import uk.gov.hmrc.cbcrfrontend.views.html._
@@ -68,12 +66,6 @@ class CBCController @Inject()(val sec: SecuredActions, val subDataService: Subsc
     utr       <- OptionT.fromOption[Future](if(Utr(utrString).isValid){ Some(Utr(utrString)) } else { None })
   } yield CBCEnrolment(cbcId,utr)
 
-  implicit def resultFuture(r:Result):Future[Result] = Future.successful(r)
-
-  private def errorRedirect(error:CBCErrors)(implicit request:Request[_]): Result = {
-    Logger.error(error.show)
-    InternalServerError(FrontendGlobal.internalServerErrorTemplate)
-  }
 
   private def saveSubscriptionDetails(s:SubscriptionDetails)(implicit hc:HeaderCarrier): Future[Unit] = for {
     _ <- cache.save(s.utr)

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/EnrolController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/EnrolController.scala
@@ -24,13 +24,13 @@ import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.libs.json._
 import uk.gov.hmrc.cbcrfrontend.auth.SecuredActions
-import uk.gov.hmrc.cbcrfrontend.connectors.{AuthConnector, TaxEnrolmentsConnector}
+import uk.gov.hmrc.cbcrfrontend.connectors.{EnrolmentsConnector, TaxEnrolmentsConnector}
 import uk.gov.hmrc.cbcrfrontend.model.Organisation
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 
 import scala.util.control.NonFatal
 @Singleton
-class EnrolController @Inject()(val sec: SecuredActions, val config:Configuration, ws:WSClient, auth:AuthConnector, enrolConnector: TaxEnrolmentsConnector) extends FrontendController {
+class EnrolController @Inject()(val sec: SecuredActions, val config:Configuration, ws:WSClient, auth:EnrolmentsConnector, enrolConnector: TaxEnrolmentsConnector) extends FrontendController {
 
   val conf = config.underlying.get[Config]("microservice.services.gg-proxy").value
 

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUpload.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUpload.scala
@@ -114,7 +114,7 @@ class FileUpload @Inject()(val sec: SecuredActions,
       _           <- EitherT.right[Future,CBCErrors,CacheMap](cache.save(Hash(sha256Hash(f))))
     } yield (errors._1, errors._2, metadata, xml.toOption)
 
-    result.fold({
+    result.fold[Future[Result]]({
       case UnexpectedState(errorMsg, _) => fileUploadService.deleteEnvelope(envelopeId).fold(
         _ => InternalServerError(FrontendGlobal.internalServerErrorTemplate),
         _ => InternalServerError(FrontendGlobal.internalServerErrorTemplate)
@@ -140,10 +140,6 @@ class FileUpload @Inject()(val sec: SecuredActions,
         Logger.error(e.getMessage,e)
         InternalServerError(FrontendGlobal.internalServerErrorTemplate)
     }
-  }
-
-  def invalidFileType = Action.async{ implicit request =>
-    Ok(fileupload.wrongFileType(includes.asideBusiness(),includes.phaseBannerBeta()))
   }
 
   private def errorsToFile(e:List[ValidationErrors], name:String) : File = {

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUpload.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUpload.scala
@@ -44,6 +44,7 @@ import uk.gov.hmrc.play.frontend.controller.FrontendController
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
+import uk.gov.hmrc.cbcrfrontend._
 
 
 @Singleton
@@ -75,18 +76,15 @@ class FileUpload @Inject()(val sec: SecuredActions,
     } yield Ok(fileupload.chooseFile(fileUploadUrl, fileName, includes.asideBusiness(), includes.phaseBannerBeta()))
 
 
-    result.leftMap { error =>
-      Logger.error(error.show)
-      InternalServerError(FrontendGlobal.internalServerErrorTemplate)
-    }.merge
+    result.leftMap(errorRedirect).merge
 
   }
 
   def fileUploadProgress(envelopeId: String, fileId: String) = Action.async { implicit request =>
     val hostName = FrontendAppConfig.cbcrFrontendHost
     val assetsLocationPrefix = FrontendAppConfig.assetsPrefix
-    Future.successful(Ok(fileupload.fileUploadProgress(includes.asideBusiness(), includes.phaseBannerBeta(),
-      envelopeId, fileId, hostName, assetsLocationPrefix)))
+    Ok(fileupload.fileUploadProgress(includes.asideBusiness(), includes.phaseBannerBeta(),
+      envelopeId, fileId, hostName, assetsLocationPrefix))
   }
 
 
@@ -124,7 +122,7 @@ class FileUpload @Inject()(val sec: SecuredActions,
         Logger.error(errorMsg)
         s
       })
-      case InvalidFileType(_) => Future.successful(Redirect(routes.FileUpload.fileInvalid()))
+      case InvalidFileType(_) => Redirect(routes.FileUpload.fileInvalid())
 
     },
       validationErrors => {
@@ -142,8 +140,11 @@ class FileUpload @Inject()(val sec: SecuredActions,
         Logger.error(e.getMessage,e)
         InternalServerError(FrontendGlobal.internalServerErrorTemplate)
     }
+  }
 
- }
+  def invalidFileType = Action.async{ implicit request =>
+    Ok(fileupload.wrongFileType(includes.asideBusiness(),includes.phaseBannerBeta()))
+  }
 
   private def errorsToFile(e:List[ValidationErrors], name:String) : File = {
     val b = Files.TemporaryFile(name, ".txt")

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/Subscription.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/Subscription.scala
@@ -31,7 +31,7 @@ import play.api.i18n.Messages.Implicits._
 import play.api.mvc.{Action, AnyContent, Result}
 import uk.gov.hmrc.cbcrfrontend._
 import uk.gov.hmrc.cbcrfrontend.auth.SecuredActions
-import uk.gov.hmrc.cbcrfrontend.connectors.{AuthConnector, BPRKnownFactsConnector}
+import uk.gov.hmrc.cbcrfrontend.connectors.{BPRKnownFactsConnector, EnrolmentsConnector, TaxEnrolmentsConnector}
 import uk.gov.hmrc.cbcrfrontend.exceptions.{CBCErrors, UnexpectedState}
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.services._
@@ -51,7 +51,7 @@ class Subscription @Inject()(val sec: SecuredActions,
                              val connector:BPRKnownFactsConnector,
                              val cbcIdService:CBCIdService,
                              val kfService:CBCKnownFactsService,
-                             val authConnector:AuthConnector)
+                             val authConnector:EnrolmentsConnector)
                             (implicit ec: ExecutionContext,
                              val playAuth:PlayAuthConnector,
                              val session:CBCSessionCache) extends FrontendController with ServicesConfig {

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/Subscription.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/Subscription.scala
@@ -118,32 +118,29 @@ class Subscription @Inject()(val sec: SecuredActions,
 
   val reconfirmEmail = sec.AsyncAuthenticatedAction() { authContext => implicit request =>
 
-    OptionT(session.read[SubscriberContact]).toRight(InternalServerError(FrontendGlobal.internalServerErrorTemplate)).fold (
-      error => error,
+    OptionT(session.read[SubscriberContact]).cata(
+      InternalServerError(FrontendGlobal.internalServerErrorTemplate),
       subscriberContactInfo => Ok(uk.gov.hmrc.cbcrfrontend.views.html.forms.reconfirmEmail(includes.asideCbc(), includes.phaseBannerBeta(), reconfirmEmailForm.fill(subscriberContactInfo.email)))
     )
+
   }
 
 
   val reconfirmEmailSubmit = sec.AsyncAuthenticatedAction() { authContext => implicit request =>
 
     reconfirmEmailForm.bindFromRequest.fold(
-
-      formWithErrors => Future.successful(BadRequest(uk.gov.hmrc.cbcrfrontend.views.html.forms.reconfirmEmail(
-        includes.asideBusiness(), includes.phaseBannerBeta(), formWithErrors
-      ))),
-      success => (for {
+      formWithErrors => BadRequest(uk.gov.hmrc.cbcrfrontend.views.html.forms.reconfirmEmail(includes.asideBusiness(), includes.phaseBannerBeta(), formWithErrors)),
+      success        => (for {
         subscriberContact <- OptionT(session.read[SubscriberContact]).toRight(UnexpectedState("SubscriberContact not found in the cache"))
         cbcId             <- OptionT(session.read[CBCId]).toRight(UnexpectedState("CBCId not found in the cache"))
         _                 <- EitherT.right[Future, CBCErrors, CacheMap](session.save[SubscriberContact](subscriberContact.copy(email = success)))
-
       } yield cbcId).fold(
-        _     => InternalServerError(FrontendGlobal.internalServerErrorTemplate),
+        error => errorRedirect(error),
         cbcId => Redirect(routes.Subscription.subscribeSuccessCbcId(cbcId.value))
       )
     )
-  }
 
+  }
 
   val utrConstraint: Constraint[String] = Constraint("constraints.utrcheck"){
     case utr if Utr(utr).isValid => Valid

--- a/app/uk/gov/hmrc/cbcrfrontend/exceptions/UnexpectedState.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/exceptions/UnexpectedState.scala
@@ -19,14 +19,16 @@ package uk.gov.hmrc.cbcrfrontend.exceptions
 import cats.Show
 import play.api.libs.json.{JsValue, Json, OFormat}
 
-sealed trait CBCErrors
+sealed trait CBCErrors extends Product with Serializable
 case class UnexpectedState(errorMsg: String, json: Option[JsValue] = None) extends CBCErrors
 case class InvalidFileType(file:String) extends CBCErrors
+case object InvalidSession extends CBCErrors
 
 object CBCErrors {
   implicit val show = Show.show[CBCErrors]{
     case UnexpectedState(errorMsg,_) => errorMsg
     case InvalidFileType(file)       => s"InvalidFileType: $file"
+    case InvalidSession              => InvalidSession.toString
   }
 }
 

--- a/app/uk/gov/hmrc/cbcrfrontend/model/CBCEnrolment.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/CBCEnrolment.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.model
+
+case class CBCEnrolment(cbcId:CBCId, utr:Utr)
+

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
@@ -18,6 +18,8 @@ package uk.gov.hmrc.cbcrfrontend.model
 
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
+import play.api.data.FormError
+import play.api.data.format.{Formats, Formatter}
 import play.api.libs.json._
 import uk.gov.hmrc.domain.Modulus23Check
 import uk.gov.hmrc.emailaddress.EmailAddress
@@ -38,6 +40,15 @@ class CBCId private(val value:String){
 }
 
 object CBCId extends Modulus23Check {
+
+  implicit val cbcFormatter = new Formatter[CBCId] {
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], CBCId] =
+      Formats.stringFormat.bind(key, data).right.flatMap { s =>
+        CBCId(s).toRight(Seq(FormError(key, "error.cbcid", Nil)))
+      }
+    override def unbind(key: String, value: CBCId): Map[String, String] = Map(key -> value.value)
+
+  }
 
   implicit val cbcIdFormat = new Format[CBCId] {
     override def writes(o: CBCId): JsValue = JsString(o.value)

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.cbcrfrontend.model
 
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
+import cats.kernel.Eq
 import play.api.data.FormError
 import play.api.data.format.{Formats, Formatter}
 import play.api.libs.json._
@@ -40,6 +41,8 @@ class CBCId private(val value:String){
 }
 
 object CBCId extends Modulus23Check {
+
+  implicit val cbcIdEq = Eq.instance[CBCId]((a,b) => a.value.equalsIgnoreCase(b.value))
 
   implicit val cbcFormatter = new Formatter[CBCId] {
     override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], CBCId] =

--- a/app/uk/gov/hmrc/cbcrfrontend/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/package.scala
@@ -24,6 +24,7 @@ import cats.data.{EitherT, OptionT, ValidatedNel}
 import cats.instances.future._
 import cats.syntax.option._
 import cats.syntax.cartesian._
+import cats.syntax.show._
 import uk.gov.hmrc.cbcrfrontend.core.ServiceResponse
 import uk.gov.hmrc.cbcrfrontend.exceptions.{CBCErrors, UnexpectedState}
 import uk.gov.hmrc.cbcrfrontend.model._
@@ -31,11 +32,22 @@ import uk.gov.hmrc.cbcrfrontend.services.CBCSessionCache
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.AuthConnector
 import uk.gov.hmrc.play.http.HeaderCarrier
+import _root_.play.api.mvc._
+import _root_.play.api.mvc.Results._
+import _root_.play.api.Logger
+import _root_.play.api.
 
 import scala.concurrent.{ExecutionContext, Future}
 
 
 package object cbcrfrontend {
+
+  implicit def resultFuture(r:Result):Future[Result] = Future.successful(r)
+
+  def errorRedirect(error:CBCErrors)(implicit request:Request[_]): Result = {
+    Logger.error(error.show)
+    InternalServerError(FrontendGlobal.internalServerErrorTemplate)
+  }
 
   def affinityGroupToUserType(a: AffinityGroup): Either[CBCErrors, UserType] = a.affinityGroup.toLowerCase.trim match {
     case "agent" => Right(Agent)

--- a/app/uk/gov/hmrc/cbcrfrontend/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/package.scala
@@ -35,7 +35,6 @@ import uk.gov.hmrc.play.http.HeaderCarrier
 import _root_.play.api.mvc._
 import _root_.play.api.mvc.Results._
 import _root_.play.api.Logger
-import _root_.play.api.
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -50,9 +49,9 @@ package object cbcrfrontend {
   }
 
   def affinityGroupToUserType(a: AffinityGroup): Either[CBCErrors, UserType] = a.affinityGroup.toLowerCase.trim match {
-    case "agent" => Right(Agent)
+    case "agent"        => Right(Agent)
     case "organisation" => Right(Organisation)
-    case other => Left(UnexpectedState(s"Unknown affinity group: $other"))
+    case other          => Left(UnexpectedState(s"Unknown affinity group: $other"))
   }
 
   implicit def utrToLeft(u:Utr): Either[Utr, CBCId] = Left[Utr,CBCId](u)

--- a/app/uk/gov/hmrc/cbcrfrontend/views/forms/enterCBCId.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/forms/enterCBCId.scala.html
@@ -23,7 +23,7 @@
 @import uk.gov.hmrc.cbcrfrontend.model._
 
 
-@(asideCbc: Html, phaseBannerBeta: Html, userType:UserType, form:Form[_], noMatch:Boolean = false)(
+@(asideCbc: Html, phaseBannerBeta: Html, userType:UserType, form:Form[_], noMatch:Boolean = false, missMatch:Boolean = false)(
 implicit request: Request[_], messages: Messages)
 
 @sidebarContent = {
@@ -51,6 +51,16 @@ implicit request: Request[_], messages: Messages)
             }
             @helper.form(uk.gov.hmrc.cbcrfrontend.controllers.routes.CBCController.submitCBCId()){
             <fieldset>
+                @if(missMatch){
+                <div class="flash error-summary error-summary--show"
+                     id="error-summary-display"
+                     role="alert"
+                     aria-labelledby="error-summary-heading"
+                     tabindex="-1">
+                    <h2 id="error-summary-heading" class="h3-heading">The country-by-country ID doesn't match our records.</h2>
+                    <p>Try again, or <a href="contact-hmrc-dummy-page">contact HMRC.</a></p>
+                </div>
+                }
                 <div class="form-group @if(errors || noMatch){form-field--error}">
                     @if(form.error("cbcId").isDefined){
                         <span class="error-notification">This should be 15 characters long

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/CBCControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/CBCControllerSpec.scala
@@ -31,6 +31,7 @@ import org.mockito.Mockito._
 import org.mockito.Matchers._
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
+import uk.gov.hmrc.cbcrfrontend.connectors.EnrolmentsConnector
 import uk.gov.hmrc.cbcrfrontend.exceptions.{CBCErrors, UnexpectedState}
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.services.{CBCSessionCache, SubscriptionDataService}
@@ -105,9 +106,11 @@ class CBCControllerSpec extends UnitSpec with ScalaFutures with OneAppPerSuite w
     implicit val authCon = authConnector(TestUsers.cbcrUser)
     val securedActions = new SecuredActionsTest(TestUsers.cbcrUser, authCon)
     implicit val cache = mock[CBCSessionCache]
+    implicit val enrol = mock[EnrolmentsConnector]
     when(cache.read[AffinityGroup](any(),any(),any())) thenReturn Future.successful(Some(AffinityGroup("Organisation")))
     when(cache.save[Utr](any())(any(),any(),any())) thenReturn Future.successful(CacheMap("id",Map.empty[String,JsValue]))
+    when(enrol.getEnrolments(any())) thenReturn Future.successful(List.empty)
 
-    new CBCController(securedActions, subDataS)
+    new CBCController(securedActions, subDataS, enrol)
   }
 }

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionSpec.scala
@@ -39,7 +39,7 @@ import org.mockito.Matchers
 import org.mockito.Matchers.{eq => EQ}
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.cbcrfrontend.connectors.{AuthConnector, BPRKnownFactsConnector}
+import uk.gov.hmrc.cbcrfrontend.connectors.{BPRKnownFactsConnector, EnrolmentsConnector, TaxEnrolmentsConnector}
 import uk.gov.hmrc.cbcrfrontend.util.CbcrSwitches
 import uk.gov.hmrc.http.cache.client.CacheMap
 
@@ -57,7 +57,7 @@ class SubscriptionSpec extends UnitSpec with ScalaFutures with OneAppPerSuite wi
   val dc = mock[BPRKnownFactsConnector]
   val cbcId = mock[CBCIdService]
   val cbcKF = mock[CBCKnownFactsService]
-  val auth  = mock[AuthConnector]
+  val auth  = mock[EnrolmentsConnector]
   implicit val cache = mock[CBCSessionCache]
   when(cache.read[AffinityGroup](EQ(AffinityGroup.format),any(),any())) thenReturn Future.successful(Some(AffinityGroup("Organisation")))
 


### PR DESCRIPTION
Main feature added:
On submission we check if the users has a bearer token and if it matches the CBC they have just entered. https://github.com/hmrc/cbcr-frontend/compare/develop...feature/CBCR-239?expand=1#diff-56ffab851849e08a6bd64010a58711b7R98

Additional things:

1. I added a couple of implicts that mean boilerplate is reduced, but it means lots of files have been touched. Sorry Peter :grimacing: 
2. Auth connector was renamed to Enrolments connector to better reflect what it does.