### PR TITLE
David/dls-357/remove compiler warnings

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyController.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cbcrfrontend.controllers
 
 import javax.inject.{Inject, Singleton}
-
 import cats.instances.future._
 import play.api.i18n.{I18nSupport, Messages, MessagesApi}
 import play.api.libs.json.Json
@@ -33,13 +32,14 @@ import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ExitSurveyController @Inject()(val config:Configuration,
                                      val audit:AuditConnector)
                                     (implicit conf:FrontendAppConfig,
-                                     val messagesApi:MessagesApi) extends FrontendController with I18nSupport{
+                                     val messagesApi:MessagesApi,
+                                     val ec: ExecutionContext) extends FrontendController with I18nSupport{
 
   val doSurvey = Action{ implicit request =>
     Ok(survey.exitSurvey( SurveyForm.surveyForm))

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/LanguageController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/LanguageController.scala
@@ -24,7 +24,6 @@ import play.api.i18n.Lang
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import play.api.i18n.Messages.Implicits._
 import uk.gov.hmrc.cbcrfrontend.util.CbcrSwitches
-//import play.api.Play.current
 
 import scala.concurrent.ExecutionContext
 

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/LanguageController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/LanguageController.scala
@@ -18,15 +18,17 @@ package uk.gov.hmrc.cbcrfrontend.controllers
 
 import javax.inject.Inject
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
-import play.api.Logger
+import play.api.{Application, Logger}
 import play.api.mvc.{Action, AnyContent, Flash, LegacyI18nSupport}
 import play.api.i18n.Lang
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import play.api.i18n.Messages.Implicits._
 import uk.gov.hmrc.cbcrfrontend.util.CbcrSwitches
-import play.api.Play.current
+//import play.api.Play.current
 
-class LanguageController @Inject()(configuration: FrontendAppConfig) extends FrontendController with LegacyI18nSupport{
+import scala.concurrent.ExecutionContext
+
+class LanguageController @Inject()(configuration: FrontendAppConfig)(implicit val ec: ExecutionContext, application: Application) extends FrontendController with LegacyI18nSupport{
   val english = Lang("en")
   val welsh = Lang("cy")
 

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
@@ -46,7 +46,7 @@ import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.cbcrfrontend.views.html.subscription.notAuthorised
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 
 @Singleton
@@ -58,7 +58,8 @@ class SharedController @Inject()(val messagesApi: MessagesApi,
                                  val authConnector:AuthConnector
                                 )(implicit val cache:CBCSessionCache,
                                   val config: Configuration,
-                                  feConfig:FrontendAppConfig) extends FrontendController with AuthorisedFunctions with I18nSupport {
+                                  feConfig:FrontendAppConfig,
+                                  val ec: ExecutionContext) extends FrontendController with AuthorisedFunctions with I18nSupport {
 
   val utrConstraint: Constraint[String] = Constraint("constraints.utrcheck"){
     case utr if Utr(utr).isValid => Valid

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/StartController.scala
@@ -33,13 +33,14 @@ import uk.gov.hmrc.cbcrfrontend.services.CBCSessionCache
 import uk.gov.hmrc.cbcrfrontend.views.html._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class StartController @Inject()(val messagesApi: MessagesApi,
                                 val authConnector:AuthConnector)(implicit val cache:CBCSessionCache,
                                                                  val config: Configuration,
-                                                                 feConfig:FrontendAppConfig) extends FrontendController with AuthorisedFunctions with I18nSupport {
+                                                                 feConfig:FrontendAppConfig,
+                                                                 val ec: ExecutionContext) extends FrontendController with AuthorisedFunctions with I18nSupport {
 
 
   val startForm: Form[String] = Form(

--- a/app/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidator.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidator.scala
@@ -454,7 +454,7 @@ class CBCBusinessRuleValidator @Inject()(messageRefService: MessageRefIdService,
         }
       }
       case (Some(Agent), _) => in.validNel
-      case (None, _) => SendingEntityOrganisationMatchError.invalidNel[XMLInfo]
+      case _ => SendingEntityOrganisationMatchError.invalidNel[XMLInfo]
     }
 
 
@@ -545,9 +545,7 @@ class CBCBusinessRuleValidator @Inject()(messageRefService: MessageRefIdService,
     x.messageSpec.messageType.getOrElse(determineMessageTypeIndic(x)) match {
       case CBC401 =>
 
-        val tin = x.reportingEntity match {
-          case Some(r) => r.tin.value
-        }
+        val tin = x.reportingEntity.fold("")(_.tin.value)
 
         reportingEntityDataService.queryReportingEntityDataTin(tin).leftMap {
           cbcErrors => {

--- a/app/uk/gov/hmrc/cbcrfrontend/typesclasses/HttpExecutor.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/typesclasses/HttpExecutor.scala
@@ -23,7 +23,6 @@ import play.api.libs.json.{JsObject, Json, Writes}
 import play.api.mvc.MultipartFormData.FilePart
 import uk.gov.hmrc.cbcrfrontend.model.{EnvelopeId, FileId}
 import uk.gov.hmrc.http._
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 
 import scala.concurrent.{ExecutionContext, Future}
 import java.net.URLEncoder._
@@ -75,7 +74,8 @@ trait HttpExecutor[U, P, I] {
     getBody: GetBody[P, I],
     http:HttpPost,
 //              TO DO - is http2 required
-    http2:HttpPut
+    http2:HttpPut,
+    ec: ExecutionContext
   ): Future[HttpResponse]
 }
 
@@ -92,7 +92,8 @@ object HttpExecutor {
       getBody: GetBody[CreateEnvelope, JsObject],
       http: HttpPost,
       //              TO DO - is http2 required
-      http2: HttpPut
+      http2: HttpPut,
+      ec: ExecutionContext
     ): Future[HttpResponse] = {
       http.POST[JsObject, HttpResponse](s"${fusUrl.url}/file-upload/envelopes", getBody(obj))
     }
@@ -110,11 +111,12 @@ object HttpExecutor {
       getBody: GetBody[UploadFile, Array[Byte]],
       http: HttpPost,
       //              TO DO - is http2 required
-      http2: HttpPut
+      http2: HttpPut,
+      ec: ExecutionContext
     ): Future[HttpResponse] = {
       import obj._
       val url = s"${fusFeUrl.url}/file-upload/upload/envelopes/$envelopeId/files/$fileId"
-      FileUploadFrontEndWS.doFormPartPost(url, fileName, contentType, ByteString.fromArray(getBody(obj)), Seq("CSRF-token" -> "nocheck"))
+       FileUploadFrontEndWS.doFormPartPost(url, fileName, contentType, ByteString.fromArray(getBody(obj)), Seq("CSRF-token" -> "nocheck"))
 
     }
   }
@@ -132,7 +134,8 @@ object HttpExecutor {
                   getBody: GetBody[FUCallbackResponse, JsObject],
                   http: HttpPost,
                   //              TO DO - is http2 required
-                  http2: HttpPut
+                  http2: HttpPut,
+                  ec: ExecutionContext
                 ): Future[HttpResponse] = {
       http.POST[JsObject, HttpResponse](s"${cbcrsUrl.url}/cbcr/file-upload-response", getBody(obj))
     }
@@ -152,7 +155,8 @@ object HttpExecutor {
                   getBody: GetBody[RouteEnvelopeRequest, RouteEnvelopeRequest],
                   http: HttpPost,
                   //              TO DO - is http2 required
-                  http2: HttpPut
+                  http2: HttpPut,
+                  ec: ExecutionContext
                 ): Future[HttpResponse] = {
       http.POST[RouteEnvelopeRequest, HttpResponse](s"${fusUrl.url}/file-routing/requests", getBody(obj))
     }

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadControllerSpec.scala
@@ -215,14 +215,14 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
     val fakeRequestUnregisteredGGId = addToken((FakeRequest("GET", "/unregistered-gg-account")))
 
     "return 200 when the envelope is created successfully" in {
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(cache.readOrCreate[EnvelopeId](any())) thenReturn OptionT.some[Future,EnvelopeId](EnvelopeId("12345678"))
       val result = partiallyMockedController.unregisteredGGAccount(fakeRequestUnregisteredGGId)
       status(result) shouldBe Status.OK
     }
     "return 500 when the is an error creating the envelope\"" in {
       TestSessionCache.succeed = false
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(fuService.createEnvelope(any(), any())) thenReturn left[EnvelopeId]("server error")
       val result = partiallyMockedController.unregisteredGGAccount(fakeRequestUnregisteredGGId)
       status(result) shouldBe Status.INTERNAL_SERVER_ERROR
@@ -234,33 +234,33 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
   "GET /fileUploadResponse/envelopeId/fileId" should {
     val fakeRequestGetFileUploadResponse  = addToken(FakeRequest("GET", "/fileUploadResponse/envelopeId/fileId"))
     "return 202 when the file is available" in {
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(fuService.getFileUploadResponse(any())(any(), any())) thenReturn right(Some(FileUploadCallbackResponse("envelopeId", "fileId", "AVAILABLE", None)):Option[FileUploadCallbackResponse])
       val result = partiallyMockedController.fileUploadResponse("envelopeId")(fakeRequestGetFileUploadResponse)
       status(result) shouldBe Status.ACCEPTED
     }
     "return 204" when {
       "the FUS hasn't updated the backend yet" in {
-        when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+        when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
         when(fuService.getFileUploadResponse(any())(any(), any())) thenReturn right[Option[FileUploadCallbackResponse]](None)
         val result = partiallyMockedController.fileUploadResponse("envelopeId")(fakeRequestGetFileUploadResponse).futureValue
         status(result) shouldBe Status.NO_CONTENT
       }
       "file is not yet available" in {
-        when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+        when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
         when(fuService.getFileUploadResponse(any())(any(), any())) thenReturn right[Option[FileUploadCallbackResponse]](Some(FileUploadCallbackResponse("envelopeId", "fileId", "QUARENTEENED",None)): Option[FileUploadCallbackResponse])
         val result = partiallyMockedController.fileUploadResponse("envelopeId")(fakeRequestGetFileUploadResponse).futureValue
         status(result) shouldBe Status.NO_CONTENT
       }
     }
     "return a 200" in {
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       val request = addToken(FakeRequest("GET", "fileUploadProgress/envelopeId/fileId"))
       val result = partiallyMockedController.fileUploadProgress("test","test")(request)
       status(result) shouldBe Status.OK
     }
     "return a 500 if the envelopeId doesn't match with the cache" in {
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       val request = addToken(FakeRequest("GET", "fileUploadProgress/envelopeId/fileId"))
       val result = partiallyMockedController.fileUploadProgress("test2","test")(request)
       status(result) shouldBe Status.INTERNAL_SERVER_ERROR
@@ -474,14 +474,14 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
   "The file-upload error call back" should {
     "cause a redirect to file-too-large if the response has status-code 413" in {
       val request = addToken(FakeRequest())
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       val result = Await.result(partiallyMockedController.handleError(413, "no reason")(request), 5.second)
       result.header.headers("Location") should endWith("file-too-large")
       status(result) shouldBe Status.SEE_OTHER
     }
     "cause a redirect to invalid-file-type if the response has status-code 415" in {
       val request = addToken(FakeRequest())
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       val result = Await.result(partiallyMockedController.handleError(415, "no reason")(request), 5.second)
       result.header.headers("Location") should endWith("invalid-file-type")
       status(result) shouldBe Status.SEE_OTHER
@@ -491,7 +491,7 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
   "getBusinessRuleErrors" should {
     "return 200 if error details found in cache" in {
       val request = addToken(FakeRequest())
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(cache.readOption[AllBusinessRuleErrors](EQ(AllBusinessRuleErrors.format),any(),any())) thenReturn Future.successful(Some(AllBusinessRuleErrors(List(TestDataError))))
       when(file.delete) thenReturn Future.successful(true)
       when(fuService.errorsToFile(any(),any())(any())) thenReturn validFile
@@ -501,7 +501,7 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
 
     "return 203 if no error content found in cache" in {
       val request = addToken(FakeRequest())
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(cache.readOption[AllBusinessRuleErrors](EQ(AllBusinessRuleErrors.format),any(),any())) thenReturn Future.successful(None)
       when(file.delete) thenReturn Future.successful(true)
       val result = controller.getBusinessRuleErrors(request)
@@ -512,7 +512,7 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
   "getXmlSchemaErrors" should {
     "return 200 if error details found in cache" in {
       val request = addToken(FakeRequest())
-      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(cache.readOption[XMLErrors](EQ(XMLErrors.format),any(),any())) thenReturn Future.successful(Some(XMLErrors(List("Big xml error"))))
       when(file.delete) thenReturn Future.successful(true)
       when(fuService.errorsToFile(any(),any())(any())) thenReturn validFile
@@ -522,7 +522,7 @@ class FileUploadControllerSpec extends UnitSpec with ScalaFutures with GuiceOneA
 
     "return 203 if no error content found in cache" in {
       val request = addToken(FakeRequest())
-      when(authConnector.authorise[Any](any(), any())(any(), any())) thenReturn Future.successful()
+      when(authConnector.authorise[Any](any(), any())(any(), any())) thenReturn Future.successful((): Unit)
       when(cache.readOption[XMLErrors](EQ(XMLErrors.format), any(), any())) thenReturn Future.successful(None)
       when(file.delete) thenReturn Future.successful(true)
       val result = controller.getXmlSchemaErrors(request)

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/LanguageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/LanguageControllerSpec.scala
@@ -30,6 +30,7 @@ import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import play.api.http.HeaderNames._
 import uk.gov.hmrc.cbcrfrontend.util
+import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.cbcrfrontend.util.{CbcrSwitches, FeatureSwitch}
 
 

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SharedControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SharedControllerSpec.scala
@@ -44,8 +44,8 @@ import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import uk.gov.hmrc.play.test.UnitSpec
-
 import scala.concurrent.ExecutionContext.Implicits.global
+
 import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -103,7 +103,7 @@ class SharedControllerSpec extends UnitSpec with ScalaFutures with GuiceOneAppPe
   val schemaVer: String = "1.0"
   when(configuration.getString(s"${runMode.env}.oecd-schema-version")) thenReturn Future.successful(Some(schemaVer))
 
-  val controller = new SharedController(messagesApi, subService,bprKF,auditC,env,authC)(cache,config, feConfig)
+  val controller = new SharedController(messagesApi, subService,bprKF,auditC,env,authC)(cache,config, feConfig, ec)
 
   val utr = Utr("7000000001")
   val bpr = BusinessPartnerRecord("safeid",None,EtmpAddress("Line1",None,None,None,None,"GB"))
@@ -192,7 +192,7 @@ class SharedControllerSpec extends UnitSpec with ScalaFutures with GuiceOneAppPe
       status(controller.verifyKnownFactsOrganisation(fakeRequestSubscribe)) shouldBe Status.OK
     }
     "return 200 if an Agent" in {
-      when(authC.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+      when(authC.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
       when(cache.readOption[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), any(),any())) thenReturn Future.successful(Some(bpr))
       when(cache.readOption[Utr](EQ(Utr.utrRead),any(),any())) thenReturn Future.successful(Some(utr))
       when(auditC.sendEvent(any())(any(),any())) thenReturn Future.successful(AuditResult.Success)
@@ -339,7 +339,7 @@ class SharedControllerSpec extends UnitSpec with ScalaFutures with GuiceOneAppPe
 
     "redirect to signOutSurvey page and return 200" in {
       val request = addToken(FakeRequest())
-      when(authC.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authC.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       when(feConfig.cbcrFrontendHost) thenReturn "http://localhost:9696"
       when(feConfig.governmentGatewaySignOutUrl) thenReturn "http://localhost:9025"
       val result = controller.signOutSurvey(request)
@@ -348,7 +348,7 @@ class SharedControllerSpec extends UnitSpec with ScalaFutures with GuiceOneAppPe
 
     "keepSessionAlive returns 200" in {
       val request = addToken(FakeRequest())
-      when(authC.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful()
+      when(authC.authorise[Any](any(),any())(any(), any())) thenReturn Future.successful((): Unit)
       val result = controller.keepSessionAlive(request)
       status(result) shouldBe Status.OK
     }

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/StartControllerSpec.scala
@@ -41,6 +41,7 @@ import uk.gov.hmrc.cbcrfrontend.services.CBCSessionCache
 import uk.gov.hmrc.play.test.UnitSpec
 import play.api.http.Status
 import uk.gov.hmrc.cbcrfrontend.model.DocRefIdResponses.Ok
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionSpec.scala
@@ -778,7 +778,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
     "return 200" when {
       "calling notRegistered" in {
         val request = addToken(FakeRequest())
-        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
         val result = controller.notRegistered(request)
         status(result) shouldBe Status.OK
         val webPageAsString = contentAsString(result)
@@ -787,7 +787,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
 
       "calling noIndividuals" in {
         val request = addToken(FakeRequest())
-        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
         val result = controller.noIndividuals(request)
         status(result) shouldBe Status.OK
         val webPageAsString = contentAsString(result)
@@ -796,7 +796,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
 
       "calling noAssistants" in {
         val request = addToken(FakeRequest())
-        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
         val result = controller.noAssistants(request)
         status(result) shouldBe Status.OK
         val webPageAsString = contentAsString(result)
@@ -805,7 +805,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
 
       "calling upe" in {
         val request = addToken(FakeRequest())
-        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
         val result = controller.upe(request)
         status(result) shouldBe Status.OK
         val webPageAsString = contentAsString(result)
@@ -814,7 +814,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
 
       "calling utr" in {
         val request = addToken(FakeRequest())
-        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
         val result = controller.utr(request)
         status(result) shouldBe Status.OK
         val webPageAsString = contentAsString(result)
@@ -823,7 +823,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
 
       "calling enterCompanyName" in {
         val request = addToken(FakeRequest())
-        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+        when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
         val result = controller.enterCompanyName(request)
         status(result) shouldBe Status.OK
         val webPageAsString = contentAsString(result)
@@ -835,7 +835,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
     "return 303 if valid company details passed in request" in {
       val data = Json.obj("companyName" -> "Any Old Co")
       val request = addToken(FakeRequest()).withJsonBody(data)
-      when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+      when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
       when(cache.save(any())(any(),any(),any())) thenReturn Future.successful(CacheMap("",Map.empty[String,JsValue]))
       val result = controller.saveCompanyName(request)
       status(result) shouldBe Status.SEE_OTHER
@@ -844,7 +844,7 @@ class SubmissionSpec  extends UnitSpec with GuiceOneAppPerSuite with CSRFTest wi
     "return 400 if company details in request are invalid" in {
       val data = Json.obj("sas" -> "Any Old Iron")
       val request = addToken(FakeRequest()).withJsonBody(data)
-      when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful()
+      when(auth.authorise[Any](any(),any())(any(),any())) thenReturn Future.successful((): Unit)
       when(cache.save(any())(any(),any(),any())) thenReturn Future.successful(CacheMap("",Map.empty[String,JsValue]))
       val result = controller.saveCompanyName(request)
       status(result) shouldBe Status.BAD_REQUEST

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCXMLValidatorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCXMLValidatorSpec.scala
@@ -26,7 +26,6 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.cbcrfrontend.services.{CBCRXMLValidator, RunMode}
 
 class CBCXMLValidatorSpec extends WordSpec with Matchers with GuiceOneAppPerSuite with MockitoSugar {
 


### PR DESCRIPTION
# DLS-357 - Remove compiler warnings from FE (min 50%) CBC

Maintenance

Reduced the total amount of compiler warnings down from around 100 to about 25. Around 20 or so of the warnings couldn't be removed because they refer to the deprecation of anyObject(), which will be removed in Mockito 3.0.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [N/A ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.) 
 - [x (squash and merge) ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ N/A (didn't add any dependencies)]  I've run a dependency check to ensure all dependencies are up to date