### PR TITLE
DLS-1313 GTM Script appearing in CBC front-end

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/views/govuk_wrapper.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/govuk_wrapper.scala.html
@@ -105,7 +105,6 @@
 
 @mainContentHeader = {
 @if(contentHeader.isDefined) {
-    googleTagScript
     @uiLayouts.main_content_header(contentHeader = contentHeader.get)
 }
 }


### PR DESCRIPTION
DLS-1313 - Removing the googleTagScript keyword froml Gov Wrapper

The keyword googleTagScript thats appearing in Technical Difficulties page is now removed.
## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date