### PR TITLE
DLS-2890 CBC - The upload file size is displayed wrongly in the summary page

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/package.scala
@@ -141,9 +141,11 @@ package object cbcrfrontend {
             metadata.status,
             metadata.name,
             metadata.contentType,
-            metadata.length,
+            calculateFileSize(metadata),
             metadata.created)
         )
       }
+  def calculateFileSize(md: FileMetadata): BigDecimal =
+    (md.length / 1000).setScale(2, BigDecimal.RoundingMode.HALF_UP)
 
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/package.scala
@@ -141,11 +141,8 @@ package object cbcrfrontend {
             metadata.status,
             metadata.name,
             metadata.contentType,
-            calculateFileSize(metadata),
+            metadata.length,
             metadata.created)
         )
       }
-  def calculateFileSize(md: FileMetadata): BigDecimal =
-    (md.length / 1000).setScale(2, BigDecimal.RoundingMode.HALF_UP)
-
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/util/ModifySize.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/util/ModifySize.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.util
+
+object ModifySize {
+  def calculateFileSize(length: BigDecimal): BigDecimal =
+    (length / 1000).setScale(2, BigDecimal.RoundingMode.HALF_UP)
+}

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSummary.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSummary.scala.html
@@ -21,6 +21,7 @@
 @import uk.gov.hmrc.cbcrfrontend.controllers.routes
 @import uk.gov.hmrc.cbcrfrontend.model._
 @import uk.gov.hmrc.cbcrfrontend.views.html.main_template
+@import uk.gov.hmrc.cbcrfrontend.util.ModifySize
 
 @this(mainTemplate: main_template)
 
@@ -51,7 +52,6 @@
                 <div class="tabular-data__data-1">@summaryData.submissionMetaData.submissionInfo.tin.value</div>
             </div>
             <br>
-
             <div class="tabular-data__entry divider--bottom">
                 <h2 class="tabular-data__heading tabular-data__heading--label">@Messages("submitSummary.contactDetails.heading")</h2>
             </div>
@@ -82,7 +82,7 @@
             </div>
             <div class="tabular-data__entry divider--bottom">
                 <span class="tabular-data__heading">@Messages("submitSummary.reportDetails.fileSize")</span>
-                <div class="tabular-data__data-1">@summaryData.submissionMetaData.fileInfo.length KB</div>
+                <div class="tabular-data__data-1">@ModifySize.calculateFileSize(summaryData.submissionMetaData.fileInfo.length) KB</div>
             </div>
             <div class="tabular-data__entry divider--bottom">
                 <span class="tabular-data__heading">@Messages("submitSummary.reportDetails.period")</span>


### PR DESCRIPTION
# JIRA Story - DLS-2890 CBC - The upload file size is displayed wrongly in the summary page

**Bug fix ** 

Please include a summary / description of the change and which issue it fixes.  Include any relevant user needs, context or links to other PRs related to this PR (eg. acceptance tests, environment config).

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date