### PR TITLE
DLS-6649: [RP] Fix for Large xml audit file issue.

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
@@ -162,7 +162,7 @@ class SubmissionController @Inject()(
                          }
                      _ <- right(cache.save(SubmissionDate(LocalDateTime.now)))
                      _ <- storeOrUpdateReportingEntityData(xml)
-                     _ = createSuccessfulSubmissionAuditEvent(retrieval.a.get, summaryData).value.map {
+                     _ <- createSuccessfulSubmissionAuditEvent(retrieval.a.get, summaryData).value.map {
                        case Left(_) =>
                          logger.error("create SuccessfulSubmissionAuditEvent failed.")
                      }

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
@@ -162,7 +162,7 @@ class SubmissionController @Inject()(
                          }
                      _ <- right(cache.save(SubmissionDate(LocalDateTime.now)))
                      _ <- storeOrUpdateReportingEntityData(xml)
-                     _ <- createSuccessfulSubmissionAuditEvent(retrieval.a.get, summaryData).value.map {
+                     _ = createSuccessfulSubmissionAuditEvent(retrieval.a.get, summaryData).value.map {
                        case Left(_) =>
                          logger.error("create SuccessfulSubmissionAuditEvent failed.")
                      }


### PR DESCRIPTION
# DLS-6649 Submission and audit event file size increase

**Bug fix 
When user submits CBCR report - large xml file, audit event was throwing a `413 TooLargeEntity` Error
As part of this bug fix, we are trying to reduce that audit event size by removing `additionalInfo` field from xml file.

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date