### PR TITLE
DLS-6967 Extra Logging around submission/file upload

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadController.scala
@@ -224,7 +224,8 @@ class FileUploadController @Inject()(
               else if (result.isLeft) auditFailedSubmission(creds, affinity, enrolment, "business rules errors")
               else EitherT.pure[Future, CBCErrors, Unit](())
           _ = java.nio.file.Files.deleteIfExists(file_metadata._1.toPath)
-        } yield
+        } yield {
+          logger.info(s"FileUpload succeeded - envelopeId: ${envelopeId}")
           Ok(
             views.fileUploadResult(
               affinity,
@@ -233,6 +234,7 @@ class FileUploadController @Inject()(
               schemaSize,
               businessSize,
               result.map(_.reportingEntity.reportingRole).toOption))
+        }
 
         result
           .leftMap {

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
@@ -163,8 +163,11 @@ class SubmissionController @Inject()(
                      _ <- right(cache.save(SubmissionDate(LocalDateTime.now)))
                      _ <- storeOrUpdateReportingEntityData(xml)
                      _ = createSuccessfulSubmissionAuditEvent(retrieval.a.get, summaryData).value.map {
-                       case Left(_) =>
-                         logger.error("create SuccessfulSubmissionAuditEvent failed.")
+                       case Left(_) => logger.error("create SuccessfulSubmissionAuditEvent failed.")
+                     }
+                     _ = {
+                       import summaryData.submissionMetaData.fileInfo.{envelopeId, name}
+                       logger.info(s"Successfully uploaded file: $name, envelopeId: $envelopeId")
                      }
                    } yield
                      retrieval.b match {


### PR DESCRIPTION
# [DLS-6967](https://jira.tools.tax.service.gov.uk/browse/DLS-6967) - Add extra logging

Adds a little bit of extra logging around file upload and submission to help with debugging live issues.

Context: We often have to get the file name/envelope ID from splunk to send to FileUpload team to confirm that the file was sent to DES. This feature makes it so we don't have to ask Splunk people for this data and make debugging quicker.

**New feature**

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date