### PR TITLE
DLS-6253: Updated cats dependency

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyController.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.cbcrfrontend.controllers
 
+import cats.data.EitherT
 import cats.instances.future._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
@@ -69,7 +70,7 @@ class ExitSurveyController @Inject()(
 
   def auditSurveyAnswers(answers: SurveyAnswers)(
     implicit request: Request[_]): ServiceResponse[AuditResult.Success.type] =
-    eitherT[AuditResult.Success.type](
+    EitherT(
       audit
         .sendExtendedEvent(
           ExtendedDataEvent("Country-By-Country-Frontend", "CBCRExitSurvey", detail = Json.toJson(answers)))
@@ -78,5 +79,4 @@ class ExitSurveyController @Inject()(
           case AuditResult.Success         => Right(AuditResult.Success)
           case AuditResult.Failure(msg, _) => Left(UnexpectedState(s"Unable to audit an exit survey: $msg"))
         })
-
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
@@ -244,7 +244,7 @@ class SharedController @Inject()(
                       logger.warn("The BPR was not found when looking it up with the knownFactsService")
                       NotFoundView(knownFacts, userType)
                     }
-              cbcIdFromXml <- EitherT.right[Future, Result, Option[CBCId]](
+              cbcIdFromXml <- EitherT.right(
                                OptionT(cache.readOption[CompleteXMLInfo]).map(_.messageSpec.sendingEntityIn).value)
               subscriptionDetails <- subDataService
                                       .retrieveSubscriptionData(knownFacts.utr)
@@ -272,7 +272,7 @@ class SharedController @Inject()(
                     case _ =>
                       Right(())
                   })
-              _ <- EitherT.right[Future, Result, Unit](
+              _ <- EitherT.right(
                     (cache.save(bpr) *>
                       cache.save(knownFacts.utr) *>
                       cache.save(TIN(knownFacts.utr.value, ""))).map(_ => ()))

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/package.scala
@@ -16,26 +16,13 @@
 
 package uk.gov.hmrc.cbcrfrontend
 
-import cats.data.EitherT
-import cats.instances.all._
 import play.api.libs.json.Json
 import uk.gov.hmrc.auth.core.Enrolments
 import uk.gov.hmrc.auth.core.retrieve.Credentials
-import uk.gov.hmrc.cbcrfrontend.model.{CBCErrors, ExpiredSession}
-
-import scala.concurrent.{ExecutionContext, Future}
 
 package object controllers {
 
   val enrolmentsFormat = Json.format[Enrolments]
   val credentialsFormat = Json.format[Credentials]
 
-  def pure[A](a: A)(implicit ec: ExecutionContext) = EitherT.pure[Future, CBCErrors, A](a)
-  def right[A](a: Future[A])(implicit ec: ExecutionContext) = EitherT.right[Future, CBCErrors, A](a)
-  def rightE[A](a: Future[A])(implicit ec: ExecutionContext) = EitherT.right[Future, ExpiredSession, A](a)
-  def left[A](e: CBCErrors)(implicit ec: ExecutionContext) = EitherT.left[Future, CBCErrors, A](Future.successful(e))
-  def leftE[A](e: ExpiredSession)(implicit ec: ExecutionContext) =
-    EitherT.left[Future, ExpiredSession, A](Future.successful(e))
-  def fromEither[A, B](e: Either[A, B])(implicit ec: ExecutionContext) = EitherT.fromEither[Future](e)
-  def eitherT[A](a: Future[Either[CBCErrors, A]]) = EitherT[Future, CBCErrors, A](a)
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/services/EnrolmentsService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/EnrolmentsService.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.cbcrfrontend.services
 
+import cats.data.EitherT
 import uk.gov.hmrc.cbcrfrontend.connectors.TaxEnrolmentsConnector
-import uk.gov.hmrc.cbcrfrontend.controllers._
 import uk.gov.hmrc.cbcrfrontend.core.ServiceResponse
 import uk.gov.hmrc.cbcrfrontend.model.{CBCKnownFacts, UnexpectedState}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -30,8 +30,7 @@ import scala.util.control.NonFatal
 class EnrolmentsService @Inject()(tec: TaxEnrolmentsConnector)(implicit ec: ExecutionContext) {
 
   def enrol(cbcKnownFacts: CBCKnownFacts)(implicit hc: HeaderCarrier): ServiceResponse[Unit] =
-    eitherT[Unit](tec.enrol(cbcKnownFacts.cBCId, cbcKnownFacts.utr).map(_ => Right(())).recover {
+    EitherT(tec.enrol(cbcKnownFacts.cBCId, cbcKnownFacts.utr).map(_ => Right(())).recover {
       case NonFatal(t) => Left(UnexpectedState(s"Failed to call enrol: ${t.getMessage}"))
     })
-
 }

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,10 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),
     // ***************
     // Use the silencer plugin to suppress warnings
-    scalacOptions += "-P:silencer:pathFilters=routes;views",
+    scalacOptions ++= Seq(
+      "-P:silencer:pathFilters=routes;views",
+      "-Ypartial-unification"
+    ),
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,26 +3,29 @@ import sbt.*
 
 object AppDependencies {
   val hmrcBootstrapVersion = "5.25.0"
+  val mockitoScalaVersion = "1.17.12"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.25.0",
     "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "0.94.0-play-28",
     "uk.gov.hmrc"       %% "emailaddress"               % "3.7.0",
     "uk.gov.hmrc"       %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc"       %% "http-caching-client"        % "9.6.0-play-28",
-    "org.typelevel"     %% "cats"                       % "0.9.0",
+    "org.typelevel"     %% "cats-core"                  % "1.0.0",
     "com.github.kxbmap" %% "configs"                    % "0.6.0",
     "com.scalawilliam"  %% "xs4s"                       % "0.5",
     "commons-io"        % "commons-io"                  % "2.6",
     "org.mindrot"       % "jbcrypt"                     % "0.4"
   )
 
-  def test(scope: String = "test") = Seq(
+  def test(scope: String = "test"): Seq[ModuleID] = Seq(
     "org.pegdown"              % "pegdown"             % "1.6.0" % scope,
-    "org.scalatestplus.play"   %% "scalatestplus-play" % "5.0.0" % scope,
-    "org.mockito"              % "mockito-core"        % "3.11.0" % scope,
+    "org.scalatestplus.play"   %% "scalatestplus-play" % "5.1.0" % scope,
+    "org.mockito"              %% "mockito-scala"      % mockitoScalaVersion % scope,
+    "org.mockito"              %% "mockito-scala-cats" % mockitoScalaVersion % scope,
     "com.sun.msv.datatype.xsd" % "xsdlib"              % "2013.2",
     "msv"                      % "msv"                 % "20050913",
+    "com.vladsch.flexmark"     % "flexmark-all"        % "0.35.10" % scope
   )
 }

--- a/test/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadControllerServiceConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadControllerServiceConnectorSpec.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.cbcrfrontend.connectors
 
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatest.{EitherValues, Matchers}
 import play.api.http.HeaderNames.LOCATION
 import play.api.libs.json.{JsNull, Json}

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/CBCEnhancementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/CBCEnhancementsControllerSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.cbcrfrontend.controllers
 
+import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
 import play.api.i18n.MessagesApi
@@ -31,8 +31,8 @@ import uk.gov.hmrc.cbcrfrontend.views.Views
 import scala.concurrent.ExecutionContext
 
 class CBCEnhancementsControllerSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest
+    with BeforeAndAfterEach with MockitoSugar {
   implicit val ec = app.injector.instanceOf[ExecutionContext]
   implicit val messagesApi = app.injector.instanceOf[MessagesApi]
   val mcc = app.injector.instanceOf[MessagesControllerComponents]

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/EnrolControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/EnrolControllerSpec.scala
@@ -19,10 +19,7 @@ package uk.gov.hmrc.cbcrfrontend.controllers
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
 import play.api.mvc.MessagesControllerComponents
@@ -38,8 +35,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class EnrolControllerSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   implicit val ec = app.injector.instanceOf[ExecutionContext]
   implicit val timeout = Timeout(5 seconds)
@@ -56,7 +52,6 @@ class EnrolControllerSpec
   val utr = Utr("9000000001")
 
   "Calling enrol controller" should {
-
     "return 200 when calling deEnrol if authorised Organisation and User or Admin" in {
       val fakeRequest = addToken(FakeRequest("GET", "/de-enrol"))
       val response: HttpResponse = mock[HttpResponse]
@@ -73,5 +68,4 @@ class EnrolControllerSpec
       status(controller.getEnrolments(fakeRequest)) shouldBe Status.OK
     }
   }
-
 }

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyControllerSpec.scala
@@ -18,10 +18,7 @@ package uk.gov.hmrc.cbcrfrontend.controllers
 
 import akka.util.Timeout
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import play.api.http.Status
@@ -43,8 +40,7 @@ import scala.concurrent.duration.{Duration, _}
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 class ExitSurveyControllerSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   implicit val ec = app.injector.instanceOf[ExecutionContext]
   implicit val messagesApi = app.injector.instanceOf[MessagesApi]

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/LanguageControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/LanguageControllerSpec.scala
@@ -16,10 +16,7 @@
 
 package uk.gov.hmrc.cbcrfrontend.controllers
 
-import org.mockito.Mockito._
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.HeaderNames._
 import play.api.mvc.{MessagesControllerComponents, Result}
@@ -32,8 +29,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class LanguageControllerSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   implicit val conf = mock[FrontendAppConfig]
   val mcc = app.injector.instanceOf[MessagesControllerComponents]

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/StartControllerSpec.scala
@@ -19,10 +19,9 @@ package uk.gov.hmrc.cbcrfrontend.controllers
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
+import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import play.api.Play.materializer
@@ -44,8 +43,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class StartControllerSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   implicit val feConf = mock[FrontendAppConfig]
   implicit val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
@@ -17,13 +17,13 @@
 package uk.gov.hmrc.cbcrfrontend.controllers
 
 import akka.util.Timeout
-import cats.data.{EitherT, OptionT}
-import cats.instances.future._
+import cats.data.OptionT
+import cats.data.OptionT.catsDataMonadForOptionT
+import cats.implicits.catsStdInstancesForFuture
 import org.mockito.ArgumentMatchers.{any, eq => EQ}
-import org.mockito.Mockito._
+import org.mockito.MockitoSugar
+import org.mockito.cats.MockitoCats
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Play.materializer
 import play.api.http.Status
@@ -50,10 +50,11 @@ import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 import java.time.LocalDateTime
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.language.postfixOps
 import scala.reflect.runtime.universe._
 class SubscriptionControllerSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with BeforeAndAfterEach
+    with MockitoSugar with MockitoCats {
   val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   def getMessages(r: FakeRequest[_]): Messages = messagesApi.preferred(r)
 
@@ -77,13 +78,13 @@ class SubscriptionControllerSpec
   val id = CBCId.create(5678).getOrElse(fail("bad cbcid"))
   val utr = Utr("9000000001")
   implicit val timeout = Timeout(5 seconds)
+
   override protected def afterEach(): Unit = {
     reset(cache, subService, auditMock, dc, cbcId, bprKF, cache, emailMock, auth)
     super.afterEach()
   }
 
-  when(cache.read[AffinityGroup](EQ(AffinityGroup.jsonFormat), any(), any()))
-    .thenReturn(rightE[AffinityGroup](AffinityGroup.Organisation))
+  whenF(cache.read[AffinityGroup](EQ(AffinityGroup.jsonFormat), any(), any())) thenReturn AffinityGroup.Organisation
 
   val controller =
     new SubscriptionController(
@@ -147,7 +148,6 @@ class SubscriptionControllerSpec
       status(controller.contactInfoSubscriber(fakeRequestSubscribe)) shouldBe Status.OK
     }
   }
-  //=========================================================================================================
 
   "POST /submitSubscriptionData" should {
     "return 400 when the there is no data" in {
@@ -170,6 +170,7 @@ class SubscriptionControllerSpec
       val fakeRequestSubscribe = addToken(FakeRequest("POST", "/submitSubscriptionData"))
       status(controller.submitSubscriptionData(fakeRequestSubscribe)) shouldBe Status.BAD_REQUEST
     }
+
     "return 400 when either first or last name or both are missing" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -213,6 +214,7 @@ class SubscriptionControllerSpec
         addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(data3: _*))
       status(controller.submitSubscriptionData(fakeRequestSubscribe3)) shouldBe Status.BAD_REQUEST
     }
+
     "return 400 when the email is missing" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -239,6 +241,7 @@ class SubscriptionControllerSpec
         addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(data: _*))
       status(controller.submitSubscriptionData(fakeRequestSubscribe)) shouldBe Status.BAD_REQUEST
     }
+
     "return 400 when the email is invalid" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -266,6 +269,7 @@ class SubscriptionControllerSpec
         addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(data: _*))
       status(controller.submitSubscriptionData(fakeRequestSubscribe)) shouldBe Status.BAD_REQUEST
     }
+
     "return 400 when the phone number is missing" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -320,6 +324,7 @@ class SubscriptionControllerSpec
         addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(data: _*))
       status(controller.submitSubscriptionData(fakeRequestSubscribe)) shouldBe Status.BAD_REQUEST
     }
+
     "return a custom error message when the phone number is invalid" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -354,6 +359,7 @@ class SubscriptionControllerSpec
       webPageAsString should not include ("found some errors")
       webPageAsString should not include (getMessages(fakeRequest)("contactInfoSubscriber.phoneNumber.error.empty"))
     }
+
     "return a custom error message when the phone number is empty" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -388,6 +394,7 @@ class SubscriptionControllerSpec
       webPageAsString should not include ("found some errors")
       webPageAsString should not include (getMessages(fakeRequest)("contactInfoSubscriber.phoneNumber.error.invalid"))
     }
+
     "return a custom error message when the email  is invalid" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -422,7 +429,8 @@ class SubscriptionControllerSpec
       webPageAsString should not include ("found some errors")
       webPageAsString should not include ("entered your email address")
     }
-    "return a custom error message when the frist name is empty" in {
+
+    "return a custom error message when the first name is empty" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
       val subService = mock[SubscriptionDataService]
@@ -454,6 +462,7 @@ class SubscriptionControllerSpec
       webPageAsString should include(getMessages(fakeRequest)("contactInfoSubscriber.firstName.error"))
       webPageAsString should not include ("found some errors")
     }
+
     "return a custom error message when the last name is empty" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -486,6 +495,7 @@ class SubscriptionControllerSpec
       webPageAsString should include(getMessages(fakeRequest)("contactInfoSubscriber.lastName.error"))
       webPageAsString should not include ("found some errors")
     }
+
     "return a custom error message when the email is empty" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -519,6 +529,7 @@ class SubscriptionControllerSpec
       webPageAsString should not include ("found some errors")
       webPageAsString should not include (getMessages(fakeRequest)("contactInfoSubscriber.emailAddress.error.invalid"))
     }
+
     "return 500 when the SubscriptionDataService errors" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -548,16 +559,12 @@ class SubscriptionControllerSpec
         "email"       -> sData.email.toString,
       )
       val fakeRequest = addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(dataSeq: _*))
-      when(cbcId.subscribe(any())(any())) thenReturn OptionT[Future, CBCId](Future.successful(cbcid))
-      when(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenReturn EitherT
-        .left[Future, CBCErrors, String](
-          Future.successful(UnexpectedState("return 500 when the SubscriptionDataService errors")))
-      when(subService.clearSubscriptionData(any())(any(), any())) thenReturn EitherT
-        .right[Future, CBCErrors, Option[String]](None)
+      whenF(cbcId.subscribe(any())(any())) thenReturn cbcid.get
+      whenF(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenFailWith UnexpectedState("return 500 when the SubscriptionDataService errors")
+      whenF(subService.clearSubscriptionData(any())(any(), any())) thenReturn None
       when(cache.readOption[Subscribed.type](EQ(Implicits.format), any(), any())) thenReturn Future.successful(None)
-      when(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn rightE(
-        BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB")))
-      when(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn rightE(Utr("700000002"))
+      whenF(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB"))
+      whenF(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn Utr("700000002")
       when(cache.readOption[GGId](EQ(GGId.format), any(), any())) thenReturn Future.successful(
         Some(GGId("ggid", "type")))
       when(auditMock.sendExtendedEvent(any())(any(), any())) thenReturn Future.successful(AuditResult.Success)
@@ -565,6 +572,7 @@ class SubscriptionControllerSpec
       verify(subService).clearSubscriptionData(any())(any(), any())
       verify(auditMock).sendExtendedEvent(any())(any(), any())
     }
+
     "return 500 when the getCbcId call errors out" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -590,16 +598,15 @@ class SubscriptionControllerSpec
         "email"       -> sData.email.toString,
       )
       val fakeRequest = addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(dataSeq: _*))
-      when(cache.read[SubscriptionDetails](EQ(SubscriptionDetails.subscriptionDetailsFormat), any(), any())) thenReturn rightE(
-        subscriptionDetails)
-      when(cbcId.subscribe(any())(any())) thenReturn OptionT[Future, CBCId](Future.successful(None))
+      whenF(cache.read[SubscriptionDetails](EQ(SubscriptionDetails.subscriptionDetailsFormat), any(), any())) thenReturn subscriptionDetails
+      when(cbcId.subscribe(any())(any())) thenReturn OptionT.none
       when(cache.readOption[Subscribed.type](EQ(Implicits.format), any(), any())) thenReturn Future.successful(None)
-      when(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn rightE(
-        BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB")))
-      when(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn rightE(Utr("700000002"))
+      whenF(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB"))
+      whenF(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn Utr("700000002")
       status(controller.submitSubscriptionData(fakeRequest)) shouldBe Status.INTERNAL_SERVER_ERROR
       verify(subService, times(0)).clearSubscriptionData(any())(any(), any())
     }
+
     "return 500 when the addKnownFactsToGG call errors" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -625,23 +632,21 @@ class SubscriptionControllerSpec
         "email"       -> sData.email.toString,
       )
       val fakeRequest = addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(dataSeq: _*))
-      when(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenReturn EitherT
-        .left[Future, CBCErrors, String](Future.successful(UnexpectedState("oops")))
-      when(cbcId.subscribe(any())(any())) thenReturn OptionT(Future.successful(CBCId("XGCBC0000000001")))
-      when(cbcKF.enrol(any())(any())) thenReturn EitherT.left[Future, CBCErrors, Unit](UnexpectedState("oops"))
-      when(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn rightE(
-        BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB")))
+      whenF(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenFailWith UnexpectedState("oops")
+      whenF(cbcId.subscribe(any())(any())) thenReturn CBCId("XGCBC0000000001").get
+      whenF(cbcKF.enrol(any())(any())) thenFailWith UnexpectedState("oops")
+      whenF(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB"))
       when(cache.readOption[Subscribed.type](EQ(Implicits.format), any(), any())) thenReturn Future.successful(None)
-      when(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn rightE(Utr("123456789"))
+      whenF(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn Utr("123456789")
       when(cache.readOption[GGId](EQ(GGId.format), any(), any())) thenReturn Future.successful(
         Some(GGId("ggid", "type")))
       when(auditMock.sendExtendedEvent(any())(any(), any())) thenReturn Future.successful(AuditResult.Success)
-      when(subService.clearSubscriptionData(any())(any(), any())) thenReturn EitherT
-        .right[Future, CBCErrors, Option[String]](None)
+      whenF(subService.clearSubscriptionData(any())(any(), any())) thenReturn None
       status(controller.submitSubscriptionData(fakeRequest)) shouldBe Status.INTERNAL_SERVER_ERROR
       verify(subService).clearSubscriptionData(any())(any(), any())
       verify(auditMock).sendExtendedEvent(any())(any(), any())
     }
+
     "return 303 (see_other) when all params are present and valid and the SubscriptionDataService returns Ok and send an email " in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -667,17 +672,15 @@ class SubscriptionControllerSpec
         "email"       -> sData.email.toString,
       )
       val fakeRequest = addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(dataSeq: _*))
-      when(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenReturn EitherT
-        .pure[Future, CBCErrors, String]("done")
+      whenF(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenReturn "done"
       when(cache.readOption[GGId](EQ(GGId.format), any(), any())) thenReturn Future.successful(
         Some(GGId("ggid", "type")))
-      when(cbcId.subscribe(any())(any())) thenReturn OptionT(Future.successful(CBCId("XGCBC0000000001")))
-      when(cbcKF.enrol(any())(any())) thenReturn EitherT.pure[Future, CBCErrors, Unit](())
-      when(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn rightE(
-        BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB")))
-      when(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn rightE(Utr("123456789"))
+      whenF(cbcId.subscribe(any())(any())) thenReturn CBCId("XGCBC0000000001").get
+      whenF(cbcKF.enrol(any())(any())) thenReturn ()
+      whenF(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB"))
+      whenF(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn Utr("123456789")
       when(cache.readOption[Subscribed.type](EQ(Implicits.format), any(), any())) thenReturn Future.successful(None)
-      when(cache.read[CBCId](EQ(CBCId.cbcIdFormat), any(), any())) thenReturn rightE(cbcid.getOrElse(fail("aslkjfd")))
+      whenF(cache.read[CBCId](EQ(CBCId.cbcIdFormat), any(), any())) thenReturn cbcid.getOrElse(fail("aslkjfd"))
       when(cache.readOption[SubscriptionEmailSent](EQ(SubscriptionEmailSent.SubscriptionEmailSentFormat), any(), any())) thenReturn Future
         .successful(None)
       when(cache.save[SubscriberContact](any())(any(), any(), any())) thenReturn Future.successful(
@@ -685,11 +688,12 @@ class SubscriptionControllerSpec
       when(cache.save[SubscriptionEmailSent](any())(any(), any(), any())) thenReturn Future.successful(
         CacheMap("cache", Map.empty[String, JsValue]))
       when(auditMock.sendExtendedEvent(any())(any(), any())) thenReturn Future.successful(AuditResult.Success)
-      when(emailMock.sendEmail(any())(any())) thenReturn OptionT.pure[Future, Boolean](true)
+      whenF(emailMock.sendEmail(any())(any())) thenReturn true
       status(controller.submitSubscriptionData(fakeRequest)) shouldBe Status.SEE_OTHER
       verify(subService, times(0)).clearSubscriptionData(any())(any(), any())
       verify(emailMock, times(1)).sendEmail(any())(any())
     }
+
     "not send an email if one has already been send " in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -717,14 +721,13 @@ class SubscriptionControllerSpec
       val fakeRequest = addToken(FakeRequest("POST", "/submitSubscriptionData").withFormUrlEncodedBody(dataSeq: _*))
       when(cache.readOption[GGId](EQ(GGId.format), any(), any())) thenReturn Future.successful(
         Some(GGId("ggid", "type")))
-      when(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenReturn right("done")
-      when(cbcId.subscribe(any())(any())) thenReturn OptionT(Future.successful(CBCId("XGCBC0000000001")))
-      when(cbcKF.enrol(any())(any())) thenReturn EitherT.pure[Future, CBCErrors, Unit](())
-      when(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn rightE(
-        BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB")))
-      when(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn rightE(Utr("123456789"))
+      whenF(subService.saveSubscriptionData(any(classOf[SubscriptionDetails]))(any(), any())) thenReturn "done"
+      whenF(cbcId.subscribe(any())(any())) thenReturn CBCId("XGCBC0000000001").get
+      whenF(cbcKF.enrol(any())(any())) thenReturn ()
+      whenF(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB"))
+      whenF(cache.read[Utr](EQ(Utr.utrRead), EQ(utrTag), any())) thenReturn Utr("123456789")
       when(cache.readOption[Subscribed.type](EQ(Implicits.format), any(), any())) thenReturn Future.successful(None)
-      when(cache.read[CBCId](EQ(CBCId.cbcIdFormat), any(), any())) thenReturn rightE(cbcid.getOrElse(fail("kajsjdf")))
+      whenF(cache.read[CBCId](EQ(CBCId.cbcIdFormat), any(), any())) thenReturn cbcid.getOrElse(fail("kajsjdf"))
       when(cache.readOption[SubscriptionEmailSent](EQ(SubscriptionEmailSent.SubscriptionEmailSentFormat), any(), any())) thenReturn Future
         .successful(Some(SubscriptionEmailSent()))
       when(cache.save[SubscriberContact](any())(any(), any(), any())) thenReturn Future.successful(
@@ -732,11 +735,12 @@ class SubscriptionControllerSpec
       when(cache.save[SubscriptionEmailSent](any())(any(), any(), any())) thenReturn Future.successful(
         CacheMap("cache", Map.empty[String, JsValue]))
       when(auditMock.sendExtendedEvent(any())(any(), any())) thenReturn Future.successful(AuditResult.Success)
-      when(emailMock.sendEmail(any())(any())) thenReturn OptionT.pure[Future, Boolean](true)
+      whenF(emailMock.sendEmail(any())(any())) thenReturn true
       status(controller.submitSubscriptionData(fakeRequest)) shouldBe Status.SEE_OTHER
       verify(subService, times(0)).clearSubscriptionData(any())(any(), any())
       verify(emailMock, times(0)).sendEmail(any())(any())
     }
+
     "return 500 when trying to resubmit subscription details" in {
       when(auth.authorise[Option[Credentials]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(Credentials("asdf", "gateway")))
@@ -765,7 +769,6 @@ class SubscriptionControllerSpec
       when(cache.readOption[Subscribed.type](EQ(Implicits.format), any(), any())) thenReturn Future.successful(
         Some(Subscribed))
       status(controller.submitSubscriptionData(fakeRequest)) shouldBe Status.INTERNAL_SERVER_ERROR
-
     }
   }
 
@@ -776,24 +779,23 @@ class SubscriptionControllerSpec
         when(auth.authorise[Any](any(), any())(any(), any())) thenReturn Future.successful(())
         val fakeRequestSubscribe = addToken(FakeRequest("DELETE", "/clear-subscription-data"))
         val u: Utr = Utr("7000000002")
-        when(subService.clearSubscriptionData(any())(any(), any())) thenReturn EitherT
-          .pure[Future, CBCErrors, Option[String]](Some("done"))
+        whenF(subService.clearSubscriptionData(any())(any(), any())) thenReturn Some("done")
         status(controller.clearSubscriptionData(u)(fakeRequestSubscribe)) shouldBe Status.OK
       }
+
       "return a 204 if data was no data to clear" in {
         when(auth.authorise[Any](any(), any())(any(), any())) thenReturn Future.successful(())
         val fakeRequestSubscribe = addToken(FakeRequest("DELETE", "/clear-subscription-data"))
         val u: Utr = Utr("7000000002")
-        when(subService.clearSubscriptionData(any())(any(), any())) thenReturn EitherT
-          .pure[Future, CBCErrors, Option[String]](None)
+        whenF(subService.clearSubscriptionData(any())(any(), any())) thenReturn None
         status(controller.clearSubscriptionData(u)(fakeRequestSubscribe)) shouldBe Status.NO_CONTENT
       }
+
       "return a 500 if something goes wrong" in {
         when(auth.authorise[Any](any(), any())(any(), any())) thenReturn Future.successful(())
         val fakeRequestSubscribe = addToken(FakeRequest("DELETE", "/clear-subscription-data"))
         val u: Utr = Utr("7000000002")
-        when(subService.clearSubscriptionData(any())(any(), any())) thenReturn EitherT
-          .left[Future, CBCErrors, Option[String]](UnexpectedState("oops"))
+        whenF(subService.clearSubscriptionData(any())(any(), any())) thenFailWith UnexpectedState("oops")
         status(controller.clearSubscriptionData(u)(fakeRequestSubscribe)) shouldBe Status.INTERNAL_SERVER_ERROR
       }
     }
@@ -804,7 +806,6 @@ class SubscriptionControllerSpec
       val fakeRequestSubscribe = addToken(FakeRequest("DELETE", "/clear-subscription-data"))
       val u: Utr = Utr("7000000002")
       status(controller.clearSubscriptionData(u)(fakeRequestSubscribe)) shouldBe Status.NOT_IMPLEMENTED
-
     }
   }
 
@@ -813,45 +814,41 @@ class SubscriptionControllerSpec
       when(auth.authorise[Option[CBCEnrolment]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(CBCEnrolment(id, utr)))
       val fakeRequest = addToken(FakeRequest("GET", "contact-info-subscriber"))
-      when(subService.retrieveSubscriptionData(any())(any(), any())) thenReturn EitherT
-        .pure[Future, CBCErrors, Option[SubscriptionDetails]](None)
+      whenF(subService.retrieveSubscriptionData(any())(any(), any())) thenReturn None
       val result = controller.updateInfoSubscriber()(fakeRequest)
 
       status(result) shouldEqual Status.BAD_REQUEST
-
     }
+
     "return an error if there is no etmp data" in {
       when(auth.authorise[Option[CBCEnrolment]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(CBCEnrolment(id, utr)))
       val fakeRequest = addToken(FakeRequest("GET", "contact-info-subscriber"))
-      when(subService.retrieveSubscriptionData(any())(any(), any())) thenReturn EitherT
-        .pure[Future, CBCErrors, Option[SubscriptionDetails]](Some(subscriptionDetails))
+      whenF(subService.retrieveSubscriptionData(any())(any(), any())) thenReturn Some(subscriptionDetails)
       when(cache.save(any())(any(), any(), any())) thenReturn Future.successful(
         CacheMap("", Map.empty[String, JsValue]))
-      when(cbcId.getETMPSubscriptionData(any())(any())) thenReturn OptionT.none[Future, ETMPSubscription]
+      when(cbcId.getETMPSubscriptionData(any())(any())) thenReturn OptionT.none
 
       val result = controller.updateInfoSubscriber()(fakeRequest)
 
       status(result) shouldEqual Status.BAD_REQUEST
-
     }
+
     "return OK otherwise" in {
       when(auth.authorise[Option[CBCEnrolment]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(CBCEnrolment(id, utr)))
       val fakeRequest = addToken(FakeRequest("GET", "contact-info-subscriber"))
-      when(subService.retrieveSubscriptionData(any())(any(), any())) thenReturn EitherT
-        .pure[Future, CBCErrors, Option[SubscriptionDetails]](Some(subscriptionDetails))
+      whenF(subService.retrieveSubscriptionData(any())(any(), any())) thenReturn Some(subscriptionDetails)
       when(cache.save(any())(any(), any(), any())) thenReturn Future.successful(
         CacheMap("", Map.empty[String, JsValue]))
-      when(cbcId.getETMPSubscriptionData(any())(any())) thenReturn OptionT.pure[Future, ETMPSubscription](
-        etmpSubscription)
+      whenF(cbcId.getETMPSubscriptionData(any())(any())) thenReturn etmpSubscription
 
       val result = controller.updateInfoSubscriber()(fakeRequest)
 
       status(result) shouldEqual Status.OK
-
     }
   }
+
   "POST contact-info-subscriber" should {
     "validate the form fields and return BadRequest" when {
       "the first name is not provided" in {
@@ -866,6 +863,7 @@ class SubscriptionControllerSpec
         val result = call(controller.saveUpdatedInfoSubscriber, fakeRequest)
         status(result) shouldEqual Status.BAD_REQUEST
       }
+
       "the surname is not provided" in {
         val data = Seq(
           "phoneNumber" -> "0891505050",
@@ -877,8 +875,8 @@ class SubscriptionControllerSpec
         val fakeRequest = addToken(FakeRequest("POST", "contact-info-subscriber").withFormUrlEncodedBody(data: _*))
         val result = call(controller.saveUpdatedInfoSubscriber, fakeRequest)
         status(result) shouldEqual Status.BAD_REQUEST
-
       }
+
       "the phone number is not provided" in {
         val data = Seq(
           "email"     -> "blagh@blagh.com",
@@ -890,8 +888,8 @@ class SubscriptionControllerSpec
         val fakeRequest = addToken(FakeRequest("POST", "contact-info-subscriber").withFormUrlEncodedBody(data: _*))
         val result = call(controller.saveUpdatedInfoSubscriber, fakeRequest)
         status(result) shouldEqual Status.BAD_REQUEST
-
       }
+
       "the phone number is invalid" in {
         val data = Seq(
           "phoneNumber" -> "I'm not a phone number",
@@ -905,6 +903,7 @@ class SubscriptionControllerSpec
         val result = call(controller.saveUpdatedInfoSubscriber, fakeRequest)
         status(result) shouldEqual Status.BAD_REQUEST
       }
+
       "the email is not provided" in {
         val data = Seq(
           "phoneNumber" -> "0891505050",
@@ -916,8 +915,8 @@ class SubscriptionControllerSpec
         val fakeRequest = addToken(FakeRequest("POST", "contact-info-subscriber").withFormUrlEncodedBody(data: _*))
         val result = call(controller.saveUpdatedInfoSubscriber, fakeRequest)
         status(result) shouldEqual Status.BAD_REQUEST
-
       }
+
       "the email is invalid" in {
         val data = Seq(
           "phoneNumber" -> "0891505050",
@@ -932,6 +931,7 @@ class SubscriptionControllerSpec
         status(result) shouldEqual Status.BAD_REQUEST
       }
     }
+
     "call update on the ETMPSubscription data api and the internal subscription data api on the backend" in {
       val data = Seq(
         "phoneNumber" -> "0891505050",
@@ -943,19 +943,12 @@ class SubscriptionControllerSpec
       val fakeRequest = addToken(FakeRequest("POST", "contact-info-subscriber").withFormUrlEncodedBody(data: _*))
       when(auth.authorise[Option[CBCEnrolment]](any(), any())(any(), any())) thenReturn Future.successful(
         Some(CBCEnrolment(id, utr)))
-      when(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn rightE(
-        BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB")))
-      when(cache.read[CBCId](EQ(CBCId.cbcIdFormat), any(), any())) thenReturn rightE(
-        CBCId("XGCBC0000000001").getOrElse(fail("lsadkjf")))
-      when(cbcId.updateETMPSubscriptionData(any(), any())(any())) thenReturn EitherT
-        .right[Future, CBCErrors, UpdateResponse](UpdateResponse(LocalDateTime.now()))
-      when(subService.updateSubscriptionData(any(), any())(any(), any())) thenReturn EitherT
-        .right[Future, CBCErrors, String]("Ok")
+      whenF(cache.read[BusinessPartnerRecord](EQ(BusinessPartnerRecord.format), EQ(bprTag), any())) thenReturn BusinessPartnerRecord("safeid", None, EtmpAddress("Line1", None, None, None, None, "GB"))
+      whenF(cache.read[CBCId](EQ(CBCId.cbcIdFormat), any(), any())) thenReturn CBCId("XGCBC0000000001").getOrElse(fail("lsadkjf"))
+      whenF(cbcId.updateETMPSubscriptionData(any(), any())(any())) thenReturn UpdateResponse(LocalDateTime.now())
+      whenF(subService.updateSubscriptionData(any(), any())(any(), any())) thenReturn "Ok"
       val result = call(controller.saveUpdatedInfoSubscriber, fakeRequest)
       status(result) shouldEqual Status.SEE_OTHER
-
     }
-
   }
-
 }

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/actions/CBCEnhancementActionSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/actions/CBCEnhancementActionSpec.scala
@@ -17,10 +17,7 @@
 package uk.gov.hmrc.cbcrfrontend.controllers.actions
 
 import com.google.inject.Inject
-import org.mockito.Mockito.when
-import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.http.Status.{OK, SEE_OTHER}
@@ -40,8 +37,7 @@ class Harness @Inject()(cbcEnhancementAction: CBCEnhancementAction) extends Inje
 }
 
 class CBCEnhancementActionSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar
-    with BeforeAndAfterEach {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   val mockFrontendAppConfig = mock[FrontendAppConfig]
 

--- a/test/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsServiceSpec.scala
@@ -17,8 +17,7 @@
 package uk.gov.hmrc.cbcrfrontend.services
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.libs.json.Json

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCXMLValidatorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCXMLValidatorSpec.scala
@@ -19,8 +19,7 @@ package uk.gov.hmrc.cbcrfrontend.services
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import org.codehaus.stax2.validation.{XMLValidationSchema, XMLValidationSchemaFactory}
-import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.{Configuration, Environment}

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CreationDateSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CreationDateSpec.scala
@@ -16,13 +16,12 @@
 
 package uk.gov.hmrc.cbcrfrontend.services
 
-import cats.data.{EitherT, NonEmptyList}
-import cats.instances.future._
+import cats.data.NonEmptyList
+import cats.implicits.catsStdInstancesForFuture
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
+import org.mockito.MockitoSugar
+import org.mockito.cats.MockitoCats
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
 import uk.gov.hmrc.cbcrfrontend.connectors.CBCRBackendConnector
@@ -35,7 +34,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 class CreationDateSpec
-    extends UnitSpec with ScalaFutures with MockitoSugar with BeforeAndAfterEach with GuiceOneAppPerSuite {
+    extends UnitSpec with BeforeAndAfterEach with GuiceOneAppPerSuite with MockitoSugar with MockitoCats {
 
   val connector = mock[CBCRBackendConnector]
   val reportingEntity = mock[ReportingEntityDataService]
@@ -124,22 +123,19 @@ class CreationDateSpec
   "The CreationDateService" should {
     "return true" when {
       "repotingEntity creationDate is Null and default date of 2020/12/23 is less than 3 years ago" in {
-        when(reportingEntity.queryReportingEntityData(any())(any())) thenReturn EitherT
-          .pure[Future, CBCErrors, Option[ReportingEntityData]](Some(redNoCreationDate))
+        whenF(reportingEntity.queryReportingEntityData(any())(any())) thenReturn Some(redNoCreationDate)
         val result = Await.result(cds.isDateValid(xmlinfo), 5.seconds)
         result shouldBe true
       }
       "repotingEntity creationDate is less than 3 years ago" in {
-        when(reportingEntity.queryReportingEntityData(any())(any())) thenReturn EitherT
-          .pure[Future, CBCErrors, Option[ReportingEntityData]](Some(red))
+        whenF(reportingEntity.queryReportingEntityData(any())(any())) thenReturn Some(red)
         val result = Await.result(cds.isDateValid(xmlinfo), 5.seconds)
         result shouldBe true
       }
     }
     "return false" when {
       "reportingEntity creationDate is older than 3 years ago" in {
-        when(reportingEntity.queryReportingEntityData(any())(any())) thenReturn EitherT
-          .pure[Future, CBCErrors, Option[ReportingEntityData]](Some(redOldCreationDate))
+        whenF(reportingEntity.queryReportingEntityData(any())(any())) thenReturn Some(redOldCreationDate)
         val result = Await.result(cds.isDateValid(xmlinfo), 5.seconds)
         result shouldBe false
       }

--- a/test/uk/gov/hmrc/cbcrfrontend/services/DocRefIdServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/DocRefIdServiceSpec.scala
@@ -17,9 +17,7 @@
 package uk.gov.hmrc.cbcrfrontend.services
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
 import play.api.libs.json.JsNull
@@ -34,7 +32,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class DocRefIdServiceSpec extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
+class DocRefIdServiceSpec extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   val connector = mock[CBCRBackendConnector]
   val docRefIdService = new DocRefIdService(connector)

--- a/test/uk/gov/hmrc/cbcrfrontend/services/ReportingEntityDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/ReportingEntityDataServiceSpec.scala
@@ -18,9 +18,7 @@ package uk.gov.hmrc.cbcrfrontend.services
 
 import cats.data.NonEmptyList
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
 import play.api.libs.json.{JsNull, JsString, Json}
@@ -36,7 +34,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 class ReportingEntityDataServiceSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
 
   val connector = mock[CBCRBackendConnector]
   val reds = new ReportingEntityDataService(connector)

--- a/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
@@ -17,9 +17,7 @@
 package uk.gov.hmrc.cbcrfrontend.services
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
 import play.api.libs.json.{JsNull, Json}
@@ -38,7 +36,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 class SubscriptionDataServiceSpec
-    extends UnitSpec with ScalaFutures with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
+    extends UnitSpec with GuiceOneAppPerSuite with CSRFTest with MockitoSugar {
   implicit val hc: HeaderCarrier = HeaderCarrier()
   implicit val cbcrsUrl = new ServiceUrl[CbcrsUrl] { val url = "cbcr" }
   val connector = mock[CBCRBackendConnector]


### PR DESCRIPTION
Updated cats dependency to version 1.0.0, the earliest version that supports Scala 2.13
Introduced mockito-scala-cats test library
Updated scalatestplus-play version to 5.1.0 to address compilation issue
Introduced flexmark dependency as scalatestplus-play requires it
Corrected unit test 'allow agent to submit even when no enrolment' from FileUploadControllerSpec, it was not actually testing with no enrolment