### PR TITLE
DLS-6253: Updated play-frontend-hmrc library to version 3.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ lazy val microservice = Project(appName, file("."))
 
 TwirlKeys.templateImports ++= Seq(
   "uk.gov.hmrc.govukfrontend.views.html.components._",
-  "uk.gov.hmrc.govukfrontend.views.html.helpers._",
   "uk.gov.hmrc.hmrcfrontend.views.html.components._",
   "uk.gov.hmrc.hmrcfrontend.views.html.helpers._"
 )

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,6 +1,5 @@
 # microservice specific routes
 ->            /hmrc-frontend                                        hmrcfrontend.Routes
-->            /govuk-frontend                                       govuk.Routes
 
 GET           /                                                     @uk.gov.hmrc.cbcrfrontend.controllers.StartController.start
 POST          /                                                     @uk.gov.hmrc.cbcrfrontend.controllers.StartController.submit

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28" % "5.25.0",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "0.94.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"         % "3.7.0-play-28",
     "uk.gov.hmrc"       %% "emailaddress"               % "3.7.0",
     "uk.gov.hmrc"       %% "domain"                     % "8.1.0-play-28",
     "uk.gov.hmrc"       %% "http-caching-client"        % "9.6.0-play-28",


### PR DESCRIPTION
 - upgraded play-frontend-hmrc library to earliest version built for Scala 2.13