### PR TITLE
[DLS-8848] new error case for max polls

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/config/FrontendAppConfig.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/config/FrontendAppConfig.scala
@@ -37,6 +37,7 @@ class FrontendAppConfig @Inject()(
 
   val cbcrFrontendHost: String = loadConfig(s"cbcr-frontend.host")
   val fileUploadFrontendHost: String = loadConfig(s"file-upload-public-frontend.host")
+  val fileUploadMaxPolls: Int = loadConfig("maximum-js-polls").toInt
 
   val reportAProblemPartialUrl: String =
     s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadController.scala
@@ -287,6 +287,7 @@ class FileUploadController @Inject()(
   def fileInvalid: Action[AnyContent] = fileUploadError(FileNotXml)
   def fileTooLarge: Action[AnyContent] = fileUploadError(FileTooLarge)
   def fileContainsVirus: Action[AnyContent] = fileUploadError(FileContainsVirus)
+  def uploadTimedOut: Action[AnyContent] = fileUploadError(UploadTimedOut)
 
   private def fileUploadError(errorType: FileUploadErrorType) = Action.async { implicit request =>
     authorised().retrieve(Retrievals.credentials and Retrievals.affinityGroup and cbcEnrolment) {
@@ -304,6 +305,7 @@ class FileUploadController @Inject()(
       errorCode match {
         case REQUEST_ENTITY_TOO_LARGE => Redirect(routes.FileUploadController.fileTooLarge)
         case UNSUPPORTED_MEDIA_TYPE   => Redirect(routes.FileUploadController.fileInvalid)
+        case REQUEST_TIMEOUT          => Redirect(routes.FileUploadController.uploadTimedOut)
         case _                        => Redirect(routes.SharedController.technicalDifficulties)
       }
     }

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FileUploadErrorTypes.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FileUploadErrorTypes.scala
@@ -21,3 +21,4 @@ sealed trait FileUploadErrorType
 case object FileTooLarge extends FileUploadErrorType
 case object FileContainsVirus extends FileUploadErrorType
 case object FileNotXml extends FileUploadErrorType
+case object UploadTimedOut extends FileUploadErrorType

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/chooseFile.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/chooseFile.scala.html
@@ -79,6 +79,7 @@
                 data-error="@routes.SharedController.technicalDifficulties"
                 data-virus="@routes.FileUploadController.fileContainsVirus"
                 data-handle-error="@routes.FileUploadController.handleError().url"
+                data-max-polls="@config.fileUploadMaxPolls"
                 aria-live="assertive"
             >
             </span>

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadError.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadError.scala.html
@@ -21,7 +21,10 @@
 
 @(errorType: FileUploadErrorType)(implicit request: Request[_], messages: Messages)
 
-@title = @{messages("fileUploadResult.error.title")}
+@title = @{errorType match {
+    case UploadTimedOut => messages("fileUploadResult.timedOut.title")
+    case _ => messages("fileUploadResult.error.title")
+}}
 
 @layout(title, backLinkUrl = Some(routes.FileUploadController.chooseXMLFile.url)) {
 
@@ -33,10 +36,19 @@
         @messages(s"fileUploadResult.error.${errorType.toString}")
     </p>
 
-    @govukButton(Button(
-        href = Some(routes.SharedController.signOutSurvey.url),
-        content = Text(messages("form.controls.finished")),
-        attributes = Map("id" -> "btn-continue")
-    ))
+    @{errorType match {
+        case UploadTimedOut => govukButton(Button(
+            href = Some(routes.FileUploadController.chooseXMLFile.url),
+            content = Text(messages("form.controls.try-again")),
+            attributes = Map("id" -> "btn-continue")
+        ))
+        case _ =>  govukButton(Button(
+            href = Some(routes.SharedController.signOutSurvey.url),
+            content = Text(messages("form.controls.finished")),
+            attributes = Map("id" -> "btn-continue")
+        ))
+    }}
+
+
 
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -35,6 +35,7 @@ GET           /xml-schema-errors                                    @uk.gov.hmrc
 GET           /invalid-file-type                                    @uk.gov.hmrc.cbcrfrontend.controllers.FileUploadController.fileInvalid
 GET           /virus-check-failed                                   @uk.gov.hmrc.cbcrfrontend.controllers.FileUploadController.fileContainsVirus
 GET           /file-too-large                                       @uk.gov.hmrc.cbcrfrontend.controllers.FileUploadController.fileTooLarge
+GET           /upload-timed-out                                     @uk.gov.hmrc.cbcrfrontend.controllers.FileUploadController.uploadTimedOut
 GET           /failed-callback                                      @uk.gov.hmrc.cbcrfrontend.controllers.FileUploadController.handleError(errorCode:Int ?= 0, reason:String ?= "Unknown")
 GET           /unregistered-gg-account                              @uk.gov.hmrc.cbcrfrontend.controllers.FileUploadController.unregisteredGGAccount
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -142,7 +142,7 @@ file-upload-public-frontend.host = "http://localhost:9798"
 cbcr-guidance-url = "https://www.gov.uk/guidance/check-if-you-must-send-a-country-by-country-report"
 cbcr-guidance-register-url = "https://www.gov.uk/guidance/check-if-you-must-send-a-country-by-country-report#register"
 cbcr-OECD-guide-url = "http://www.hmrc.gov.uk/gds/IEIM/attachments/cbc_xml_schema_guide.pdf"
-
+maximum-js-polls = 600
 
 sessionTimeout {
   timeOutShowDialog = true

--- a/conf/messages
+++ b/conf/messages
@@ -63,6 +63,7 @@ form.controls.finished=Finished
 form.controls.returnToStart=Return to start page
 form.controls.confirmAndContinue=Confirm and continue
 form.controls.save=Save
+form.controls.try-again=Try again
 
 enterCBCId.title=Enter the country-by-country ID
 enterCBCId.formHint=This must contain the 15-character ID you received when you registered, for example: XACBC0000999999.
@@ -222,7 +223,8 @@ fileUploadResult.error.oecdInfo=for the rules you must follow.
 fileUploadResult.error.FileTooLarge=The report is larger than 50MB. You will need to fix this issue before uploading it again.
 fileUploadResult.error.FileContainsVirus=The report has failed our anti-virus checks. You will need to fix this issue before uploading it again.
 fileUploadResult.error.FileNotXml=The report is the wrong file type. You must send it as an XML file.
-
+fileUploadResult.error.UploadTimedOut=The report was not uploaded because of a temporary problem.
+fileUploadResult.timedOut.title=The report has not been uploaded
 oldfileUploadResult.notYetSubmitted=We will now ask you for more information before accepting the report.
 
 enterCompanyName.title=Enter the name of the agent organisation you work for

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadControllerSpec.scala
@@ -566,6 +566,14 @@ class FileUploadControllerSpec
       header("Location", result).get should endWith("invalid-file-type")
       status(result) shouldBe Status.SEE_OTHER
     }
+
+    "cause a redirect to upload-timed-out if maximum requests have been made" in {
+      val request = FakeRequest()
+      authConnector.authorise[Any](*, *)(*, *) returns Future.successful((): Unit)
+      val result = controller.handleError(408, "timed-out")(request)
+      header("Location", result).get should endWith("upload-timed-out")
+      status(result) shouldBe Status.SEE_OTHER
+    }
   }
 
   "getBusinessRuleErrors" should {


### PR DESCRIPTION
This pull request is for ticket DLS-8848 which aims to handle the case that an infinite number of requests (ajax polls) are permitted when an upload will never resolve. To avoid this, the ticket requests that we limit the number of requests that can be made for a single upload event. This pull request introduces a new configuration value called `maximum-js-polls` and has set it to `600` - there are 3 second intervals between polls so this amounts to 30 minutes of waiting time, the largest file permitted is 50MB and when we throttle the network to slow-3g speeds it takes 22 minutes to upload a 65MB file from the test resources. 

This pull request also fixes accessibility tickets DLS-8873 and DLS-8927 which both relate to JavaScript behaviours on uploads in this service.