### PR TITLE
DLS-8989 Only show failures and summary in tests

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/CBCRBackendConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/CBCRBackendConnector.scala
@@ -20,7 +20,7 @@ import cats.syntax.show._
 import com.typesafe.config.Config
 import configs.syntax._
 import play.api.Configuration
-import play.api.libs.json.{JsNull, JsString, JsValue, Json}
+import play.api.libs.json.{JsNull, JsString, JsValue}
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
@@ -21,7 +21,7 @@ import cats.instances.all._
 import cats.syntax.all._
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
+import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc._

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
@@ -20,7 +20,7 @@ import cats.data.{EitherT, NonEmptyList, OptionT}
 import cats.implicits._
 import play.api.data.Form
 import play.api.data.Forms._
-import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError}
+import play.api.data.validation.{Constraint, Invalid, Valid}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.{JsString, Json, OFormat}
 import play.api.mvc._

--- a/app/uk/gov/hmrc/cbcrfrontend/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/package.scala
@@ -38,7 +38,6 @@ import uk.gov.hmrc.http.HeaderCarrier
 import java.io.{File, FileInputStream}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
-import scala.util.Using
 
 package object cbcrfrontend {
 

--- a/app/uk/gov/hmrc/cbcrfrontend/views/notAuthorisedEnhancement.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/notAuthorisedEnhancement.scala.html
@@ -18,7 +18,7 @@
 
 @this(layout: uk.gov.hmrc.cbcrfrontend.views.html.Layout)
 
-@()(implicit request: Request[_], messages: Messages, config:FrontendAppConfig)
+@()(implicit request: Request[_], messages: Messages)
 
 @title = @{messages("notAuthorised.enhancement.title")}
 

--- a/app/uk/gov/hmrc/cbcrfrontend/views/start.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/start.scala.html
@@ -29,8 +29,6 @@
   messages: Messages
 )
 
-@isError= @{form.hasErrors}
-
 @title = @{messages("start.title")}
 
 @hasErrors = @{form.hasErrors}

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/enterCompanyName.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/enterCompanyName.scala.html
@@ -28,7 +28,6 @@
 @(form:Form[_], envelopeId: String, fileId: String)(implicit request: Request[_], messages: Messages)
 
 @companyNameKey = @{"companyName"}
-@error = @{form.error("companyName").isDefined}
 
 @title = @{messages("enterCompanyName.title")}
 

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val silencerVersion = "1.7.13"
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
+  .settings(onLoadMessage := "")
   .settings(
     majorVersion := 1,
     scalaVersion := "2.13.11",

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ import play.sbt.PlayImport.*
 
 val appName = "cbcr-frontend"
 
-val silencerVersion = "1.7.13"
-
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
@@ -16,20 +14,11 @@ lazy val microservice = Project(appName, file("."))
     majorVersion := 1,
     scalaVersion := "2.13.11",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test(),
-    // ***************
-    // Use the silencer plugin to suppress warnings
-    scalacOptions ++= Seq(
-      "-P:silencer:pathFilters=routes;views"
-    ),
-    libraryDependencies ++= Seq(
-      compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
-      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
-    )
-    // ***************
   )
   .settings(
-    PlayKeys.playDefaultPort := 9696
-  )
+    scalacOptions += "-Wconf:src=routes/.*:s",
+    scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s")
+  .settings(PlayKeys.playDefaultPort := 9696)
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(CodeCoverageSettings.settings *)
   // Disable default sbt Test options (might change with new versions of bootstrap)

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,11 @@ lazy val microservice = Project(appName, file("."))
   )
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(CodeCoverageSettings.settings *)
+  // Disable default sbt Test options (might change with new versions of bootstrap)
+  .settings(Test / testOptions -= Tests.Argument("-o", "-u", "target/test-reports", "-h", "target/test-reports/html-report"))
+  // Suppress successful events in Scalatest in standard output (-o)
+  // Options described here: https://www.scalatest.org/user_guide/using_scalatest_with_sbt
+  .settings(Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-oNCHPQR", "-u", "target/test-reports", "-h", "target/test-reports/html-report"))
 
 TwirlKeys.templateImports ++= Seq(
   "uk.gov.hmrc.govukfrontend.views.html.components._",

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>logs/cbcr-frontend.log</file>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message]
+                %replace(exception=[%xException]){'^exception=\[\]$',''}%n
+            </pattern>
+        </encoder>
+    </appender>
+    <root level="OFF" />
+</configuration>

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/ExitSurveyControllerSpec.scala
@@ -29,7 +29,6 @@ import play.api.mvc.MessagesControllerComponents
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{defaultAwaitTimeout, header, status}
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
-import uk.gov.hmrc.cbcrfrontend.services._
 import uk.gov.hmrc.cbcrfrontend.views.Views
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
@@ -20,7 +20,6 @@ import cats.data.OptionT
 import cats.implicits.catsStdInstancesForFuture
 import org.mockito.ArgumentMatchersSugar.{*, any}
 import org.mockito.IdiomaticMockito
-import org.mockito.IdiomaticMockito.WithExpect.{calls, expect}
 import org.mockito.cats.IdiomaticMockitoCats.StubbingOpsCats
 import org.mockito.cats.MockitoCats
 import org.scalatest.BeforeAndAfterEach

--- a/test/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsServiceSpec.scala
@@ -26,7 +26,6 @@ import uk.gov.hmrc.cbcrfrontend.model.{BPRKnownFacts, Utr}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 
-import javax.inject.Inject
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 

--- a/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
@@ -21,11 +21,10 @@ import org.mockito.IdiomaticMockito
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Configuration
 import play.api.http.Status
 import play.api.libs.json.{JsNull, Json}
 import uk.gov.hmrc.cbcrfrontend.controllers.CSRFTest
-import uk.gov.hmrc.cbcrfrontend.model.{BusinessPartnerRecord, CBCId, EtmpAddress, OrganisationResponse, SubscriberContact, SubscriptionDetails, Utr}
+import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -38,7 +37,6 @@ class SubscriptionDataServiceSpec
     extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with CSRFTest with IdiomaticMockito {
   private implicit val hc: HeaderCarrier = HeaderCarrier()
   implicit val reads: HttpReads[HttpResponse] = uk.gov.hmrc.http.HttpReads.Implicits.readRaw
-  private val runModeConfiguration = mock[Configuration]
   private val mockHttp = mock[HttpClient]
   private val servicesConfig = mock[ServicesConfig]
   private val sds = new SubscriptionDataService(mockHttp, servicesConfig)


### PR DESCRIPTION
This is something I like to do with my projects - to aid with finding failing tests quickly, I like to modify the test settings so either 
you only see errors or a summary of test failures at the end. This PR accomplishes the former. It also cleans up test run output by disabling logging in the test environment (test-only loggback.xml). Here's an example output:

## Example successful:
![image](https://github.com/hmrc/cbcr-frontend/assets/11063742/31c2cd30-0dcb-45d5-a661-a0627ffe284d)

## Example with one test failing:
![image](https://github.com/hmrc/cbcr-frontend/assets/11063742/08f82374-71d8-43c6-a155-d82bae0aeda0)

# No onLoadMessage
![image](https://github.com/hmrc/cbcr-frontend/assets/11063742/c68dae14-a942-4900-bf50-d6ecab2cc3f8)
