### PR TITLE
[DLS-9082] render technical difficulties when no subscription data

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
@@ -148,7 +148,7 @@ class SubscriptionController @Inject()(
       } yield Tuple2(subData, cbcId)
 
       subscriptionData.fold[Result](
-        (error: CBCErrors) => BadRequest(error.toString),
+        (error: CBCErrors) => errorRedirect(error, views.notAuthorisedIndividual, views.errorTemplate),
         tuple2 => {
           val subData: ETMPSubscription = tuple2._1
           val cbcId: CBCId = tuple2._2

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
@@ -497,7 +497,7 @@ class SubscriptionControllerSpec
       subService.retrieveSubscriptionData(*)(*, *) returnsF None
       val result = controller.updateInfoSubscriber()(fakeRequest)
 
-      status(result) shouldEqual Status.BAD_REQUEST
+      status(result) shouldEqual Status.INTERNAL_SERVER_ERROR
     }
 
     "return an error if there is no etmp data" in {
@@ -511,7 +511,7 @@ class SubscriptionControllerSpec
 
       val result = controller.updateInfoSubscriber()(fakeRequest)
 
-      status(result) shouldEqual Status.BAD_REQUEST
+      status(result) shouldEqual Status.INTERNAL_SERVER_ERROR
     }
 
     "return OK otherwise" in {


### PR DESCRIPTION
Previously the `BadRequest(error.toString)` response to this error case was rendering Scala error syntax as the string `UnexpectedState(No SubscriptionDetails,None)` into a blank page in the browser, now it renders the technical difficulties template and logs it as an error (HTTP 500) instead of a bad request (HTTP 400). One way to reproduce this error case is to manually delete Subscription_Data from the cbcr mongo collection by using test-only routes (can be done on localhost and Staging)