### PR TITLE
DLS-7915 | Handle empty response from DES

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/services/CBCIdService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/CBCIdService.scala
@@ -20,6 +20,7 @@ import cats.data.OptionT
 import cats.instances.future._
 import play.api.Logger
 import play.api.http.Status
+import play.api.libs.json.Json
 import uk.gov.hmrc.cbcrfrontend.connectors.CBCRBackendConnector
 import uk.gov.hmrc.cbcrfrontend.core.ServiceResponse
 import uk.gov.hmrc.cbcrfrontend.model._
@@ -52,7 +53,10 @@ class CBCIdService @Inject()(connector: CBCRBackendConnector)(implicit ec: Execu
 
   def getETMPSubscriptionData(safeId: String)(implicit hc: HeaderCarrier): OptionT[Future, ETMPSubscription] =
     OptionT(connector.getETMPSubscriptionData(safeId).map { response =>
-      Option(response.json).flatMap(_.validate[ETMPSubscription].asOpt)
+      Option(response.body)
+        .filter(_.nonEmpty)
+        .map(Json.parse)
+        .flatMap(_.validate[ETMPSubscription].asOpt)
     })
 
   def updateETMPSubscriptionData(safeId: String, correspondenceDetails: CorrespondenceDetails)(

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCIdServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCIdServiceSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.services
+
+import org.apache.http.HttpStatus
+import org.mockito.ArgumentMatchersSugar.*
+import org.mockito.IdiomaticMockito
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.http.Status
+import uk.gov.hmrc.cbcrfrontend.connectors.CBCRBackendConnector
+import uk.gov.hmrc.cbcrfrontend.controllers.CSRFTest
+import uk.gov.hmrc.cbcrfrontend.model.{ContactDetails, ContactName, ETMPSubscription, EtmpAddress}
+import uk.gov.hmrc.emailaddress.EmailAddress
+import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpResponse}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class CBCIdServiceSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with CSRFTest with IdiomaticMockito {
+
+  private val connector = mock[CBCRBackendConnector]
+  private val cbcidService = new CBCIdService(connector)
+
+  private val safeId = "safe-id"
+
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  "CBCIdService" should {
+
+    "return valid etmp subscription if the connector returns valid json object response" in {
+      val desResponse = s"""
+                           |{
+                           |   "safeId":"XP0000100099577",
+                           |   "names": {
+                           |     "name1": "name1",
+                           |     "name2": "name2"
+                           |   },
+                           |   "contact": {
+                           |     "email": "test@test.com",
+                           |     "phoneNumber": "08287623651"
+                           |   },
+                           |   "address":{
+                           |     "line1":"Delivery Day",
+                           |     "countryCode":"GB"
+                           |   }
+                           |}
+       """.stripMargin
+
+      connector.getETMPSubscriptionData(*)(*) returns Future.successful(HttpResponse(Status.OK, desResponse))
+      val result = Await.result(cbcidService.getETMPSubscriptionData(safeId).value, 2.seconds)
+      result should not be None
+      result.get shouldBe ETMPSubscription(
+        "XP0000100099577",
+        ContactName("name1", "name2"),
+        ContactDetails(EmailAddress("test@test.com"), "08287623651"),
+        EtmpAddress("Delivery Day", None, None, None, None, "GB")
+      )
+    }
+
+    "return NONE if the connector returns empty string or empty json object response" in {
+      List("", "{}").map { responseBody =>
+        connector.getETMPSubscriptionData(*)(*) returns Future.successful(HttpResponse(Status.OK, responseBody))
+        val result = Await.result(cbcidService.getETMPSubscriptionData(safeId).value, 2.seconds)
+        result shouldBe None
+      }
+    }
+
+    "throw exception if the connector fails to responds for given request" in {
+      connector.getETMPSubscriptionData(*)(*) returns Future.failed(
+        new HttpException("HttpException occurred", HttpStatus.SC_BAD_REQUEST))
+      intercept[HttpException] {
+        Await.result(cbcidService.getETMPSubscriptionData(safeId).value, 2.seconds)
+      }
+    }
+  }
+}


### PR DESCRIPTION
For cases where DES returns empty response, filter the response handling so that it's handled with similar case of empty json object which returns `None`