### PR TITLE
DLS-10863: Update service/ test pack dependencies to the latest versions

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/CBCRErrorHandler.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/CBCRErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/CBCRErrorHandler.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/CBCRErrorHandler.scala
@@ -21,9 +21,9 @@ import play.api.mvc._
 import play.api.{Configuration, Environment}
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.cbcrfrontend.auth.AuthRedirectsExternal
 import uk.gov.hmrc.cbcrfrontend.controllers.routes
 import uk.gov.hmrc.cbcrfrontend.views.Views
-import uk.gov.hmrc.play.bootstrap.config.AuthRedirects
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
 
 import javax.inject.Inject
@@ -34,7 +34,7 @@ class CBCRErrorHandler @Inject() (
   val env: Environment,
   val config: Configuration,
   views: Views
-) extends FrontendErrorHandler with Results with AuthRedirects {
+) extends FrontendErrorHandler with Results with AuthRedirectsExternal {
 
   override def resolveError(rh: RequestHeader, ex: Throwable): Result = ex match {
     case _: NoActiveSession =>

--- a/app/uk/gov/hmrc/cbcrfrontend/GuiceModule.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/GuiceModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/auth/AuthRedirectsExternal.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/auth/AuthRedirectsExternal.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.auth
+
+import play.api.mvc.Result
+import play.api.mvc.Results._
+import play.api.{Configuration, Environment, Mode}
+import uk.gov.hmrc.http.SessionKeys
+
+trait AuthRedirectsExternal {
+
+  /* Since this is a library for Play >= 2.5 we avoid depending on global configuration/environment
+   * and thus do not depend on the play-config API which still uses the deprecated globals. */
+
+  def config: Configuration
+
+  def env: Environment
+
+  private lazy val envPrefix =
+    if (env.mode.equals(Mode.Test)) "Test"
+    else
+      config
+        .getOptional[String]("run.mode")
+        .getOrElse("Dev")
+
+  private val hostDefaults: Map[String, String] = Map(
+    "Dev.external-url.bas-gateway-frontend.host"           -> "http://localhost:9553",
+    "Dev.external-url.citizen-auth-frontend.host"          -> "http://localhost:9029",
+    "Dev.external-url.identity-verification-frontend.host" -> "http://localhost:9938",
+    "Dev.external-url.stride-auth-frontend.host"           -> "http://localhost:9041"
+  )
+
+  private def host(service: String): String = {
+    val key = s"$envPrefix.external-url.$service.host"
+    config.getOptional[String](key).orElse(hostDefaults.get(key)).getOrElse("")
+  }
+
+  def ggLoginUrl: String = host("bas-gateway-frontend") + "/bas-gateway/sign-in"
+
+  def verifyLoginUrl: String = host("citizen-auth-frontend") + "/ida/login"
+
+  def personalIVUrl: String = host("identity-verification-frontend") + "/mdtp/uplift"
+
+  def strideLoginUrl: String = host("stride-auth-frontend") + "/stride/sign-in"
+
+  final lazy val defaultOrigin: String =
+    config
+      .getOptional[String]("sosOrigin")
+      .orElse(config.getOptional[String]("appName"))
+      .getOrElse("undefined")
+
+  def origin: String = defaultOrigin
+
+  def toGGLogin(continueUrl: String): Result =
+    Redirect(
+      ggLoginUrl,
+      Map(
+        "continue_url" -> Seq(continueUrl),
+        "origin"       -> Seq(origin)
+      )
+    )
+
+  def toVerifyLogin(continueUrl: String): Result = Redirect(verifyLoginUrl).withSession(
+    SessionKeys.redirect    -> continueUrl,
+    SessionKeys.loginOrigin -> origin
+  )
+
+  def toStrideLogin(successUrl: String, failureUrl: Option[String] = None): Result =
+    Redirect(
+      strideLoginUrl,
+      Map(
+        "successURL" -> Seq(successUrl),
+        "origin"     -> Seq(origin)
+      ) ++ failureUrl.map(f => Map("failureURL" -> Seq(f))).getOrElse(Map())
+    )
+
+}

--- a/app/uk/gov/hmrc/cbcrfrontend/config/FrontendAppConfig.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/config/FrontendAppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/BPRKnownFactsConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/BPRKnownFactsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/CBCRBackendConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/CBCRBackendConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/TaxEnrolmentsConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/TaxEnrolmentsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/connectors/test/TestCBCRConnector.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/connectors/test/TestCBCRConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/AuthenticationController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/AuthenticationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/CBCEnhancementsController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/CBCEnhancementsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/EnrolController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/EnrolController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SharedController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/StartController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionController.scala
@@ -361,7 +361,7 @@ class SubmissionController @Inject() (
       form <- cache.readOption[SubmitterInfo].map { osi =>
                 (osi.map(_.fullName), osi.map(_.contactPhone), osi.map(_.email))
                   .mapN { (name, phone, email) =>
-                    submitterInfoForm.bind(Map("fullName" -> name, "contactPhone" -> phone, "email" -> email.value))
+                    submitterInfoForm.bind(Map("fullName" -> name, "contactPhone" -> phone, "email" -> email))
                   }
                   .getOrElse(submitterInfoForm)
               }

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
@@ -125,7 +125,7 @@ class SubscriptionController @Inject() (
 
   private def makeSubEmail(subscriberContact: SubscriberContact, cbcId: CBCId): Email =
     Email(
-      List(subscriberContact.email.value),
+      List(subscriberContact.email),
       "cbcr_subscription",
       Map("f_name" -> subscriberContact.firstName, "s_name" -> subscriberContact.lastName, "cbcrId" -> cbcId.value)
     )
@@ -157,7 +157,7 @@ class SubscriptionController @Inject() (
             Map(
               "firstName"   -> subData.names.name1,
               "lastName"    -> subData.names.name2,
-              "email"       -> subData.contact.email.value,
+              "email"       -> subData.contact.email,
               "phoneNumber" -> subData.contact.phoneNumber
             )
           )

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionController.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.cbcrfrontend.controllers
 
+import cats.syntax.apply._
 import cats.data.EitherT
-import cats.implicits.{catsStdInstancesForFuture, catsSyntaxApply, catsSyntaxEitherId, toShow}
+import cats.implicits.{catsStdInstancesForFuture, catsSyntaxEitherId, toShow}
 import play.api.Logging
 import play.api.libs.json.{JsString, Json}
 import play.api.mvc._

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/controllers/test/TestCBCRController.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/controllers/test/TestCBCRController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/core/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/core/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/emailaddress/EmailAddress.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/emailaddress/EmailAddress.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.emailaddress
+
+import com.google.inject.ImplementedBy
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddressValidation.validEmail
+
+import javax.naming.Context.{INITIAL_CONTEXT_FACTORY => ICF}
+import javax.inject.Singleton
+import javax.naming.directory.InitialDirContext
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+import scala.util.matching.Regex
+
+case class EmailAddress(value: String) extends StringValue {
+
+  val (mailbox, domain): (Mailbox, Domain) = value match {
+    case validEmail(m, d) => (Mailbox(m), Domain(d))
+    case invalidEmail => throw new IllegalArgumentException(s"'$invalidEmail' is not a valid email address")
+  }
+
+  lazy val obfuscated: ObfuscatedEmailAddress = ObfuscatedEmailAddress.apply(value)
+
+}
+
+case class Mailbox(value: String) extends StringValue
+
+case class Domain(value: String) extends StringValue {
+  value match {
+    case EmailAddressValidation.validDomain(_) => //
+    case invalidDomain => throw new IllegalArgumentException(s"'$invalidDomain' is not a valid email domain")
+  }
+}
+
+@ImplementedBy(classOf[EmailAddressValidation])
+trait EmailValidation {
+  def isValid(email: String): Boolean
+}
+
+@Singleton
+class EmailAddressValidation extends EmailValidation {
+
+  private val DNS_CONTEXT_FACTORY = "com.sun.jndi.dns.DnsContextFactory"
+  private val env = new java.util.Hashtable[String, String]()
+  env.put(ICF, DNS_CONTEXT_FACTORY)
+
+  private def isHostMailServer(domain: String) = {
+    val ictx = new InitialDirContext(env)
+
+    def getAttributeValue(domain: String, attribute: String) =
+      Try {
+        ictx.getAttributes(domain, Array(attribute)).getAll.asScala.toList
+      }.toEither
+
+    getAttributeValue(domain, "MX") match {
+      case Right(value) if value.nonEmpty => true
+      case _ =>
+        getAttributeValue(domain, "A") match {
+          case Right(value) => value.nonEmpty
+          case Left(_) => false
+        }
+    }
+  }
+
+  def isValid(email: String): Boolean =
+    email match {
+      case validEmail(_, _) if isHostMailServer(EmailAddress(email).domain) => true
+      case _ => false
+    }
+}
+
+object EmailAddressValidation {
+  val validEmail: Regex = """^([a-zA-Z0-9.!#$%&’'*+/=?^_`{|}~-]+)@([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)$""".r
+  val validDomain: Regex = """^([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*)$""".r
+
+}
+
+
+
+
+
+

--- a/app/uk/gov/hmrc/cbcrfrontend/emailaddress/ObfuscatedEmailAddress.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/emailaddress/ObfuscatedEmailAddress.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.emailaddress
+
+import scala.language.implicitConversions
+import scala.util.matching.Regex
+
+trait ObfuscatedEmailAddress {
+  val value: String
+
+  override def toString: String = value
+}
+
+object ObfuscatedEmailAddress {
+  final private val shortMailbox: Regex = "(.{1,2})".r
+  final private val longMailbox: Regex = "(.)(.*)(.)".r
+
+  implicit def obfuscatedEmailToString(e: ObfuscatedEmailAddress): String = e.value
+
+  def apply(plainEmailAddress: String): ObfuscatedEmailAddress =
+    new ObfuscatedEmailAddress {
+      val value: String = plainEmailAddress match {
+        case EmailAddressValidation.validEmail(shortMailbox(m), domain) =>
+          s"${obscure(m)}@$domain"
+
+        case EmailAddressValidation.validEmail(longMailbox(firstLetter, middle, lastLetter), domain) =>
+          s"$firstLetter${obscure(middle)}$lastLetter@$domain"
+
+        case invalidEmail =>
+          throw new IllegalArgumentException(s"Cannot obfuscate invalid email address '$invalidEmail'")
+      }
+    }
+
+  private def obscure(text: String): String = "*" * text.length
+}

--- a/app/uk/gov/hmrc/cbcrfrontend/emailaddress/PlayJsonFormats.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/emailaddress/PlayJsonFormats.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.emailaddress
+
+import play.api.libs.json._
+
+object PlayJsonFormats {
+
+  implicit val emailAddressReads: Reads[EmailAddress] = (js: JsValue) =>
+    js.validate[String].flatMap {
+      case s if (new EmailAddressValidation).isValid(s) => JsSuccess(EmailAddress(s))
+      case _ => JsError("not a valid email address")
+    }
+  implicit val emailAddressWrites: Writes[EmailAddress] = (e: EmailAddress) => JsString(e.value)
+
+}

--- a/app/uk/gov/hmrc/cbcrfrontend/emailaddress/StringValue.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/emailaddress/StringValue.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.emailaddress
+
+import scala.language.implicitConversions
+object StringValue {
+
+  implicit def stringValueToString(e: StringValue): String = e.value
+}
+
+trait StringValue {
+  def value: String
+
+  override def toString: String = value
+}

--- a/app/uk/gov/hmrc/cbcrfrontend/form/SubmitterInfoForm.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/form/SubmitterInfoForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/form/SubmitterInfoForm.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/form/SubmitterInfoForm.scala
@@ -18,9 +18,9 @@ package uk.gov.hmrc.cbcrfrontend.form
 
 import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
+import uk.gov.hmrc.cbcrfrontend.emailaddress.{EmailAddress, EmailAddressValidation}
 import uk.gov.hmrc.cbcrfrontend.form.SubscriptionDataForm.condTrue
 import uk.gov.hmrc.cbcrfrontend.model.SubmitterInfo
-import uk.gov.hmrc.emailaddress.EmailAddress
 
 object SubmitterInfoForm {
   val submitterInfoForm: Form[SubmitterInfo] = Form(
@@ -34,9 +34,12 @@ object SubmitterInfoForm {
         ),
       "email" -> text
         .verifying("submitterInfo.emailAddress.error.empty", _.trim != "")
-        .verifying("submitterInfo.emailAddress.error.invalid", x => condTrue(x.trim != "", EmailAddress.isValid(x)))
+        .verifying(
+          "submitterInfo.emailAddress.error.invalid",
+          x => condTrue(x.trim != "", new EmailAddressValidation().isValid(x))
+        )
     ) { (fullName: String, contactPhone: String, email: String) =>
       SubmitterInfo(fullName, None, contactPhone, EmailAddress(email), None)
-    }(si => Some((si.fullName, si.contactPhone, si.email.value)))
+    }(si => Some((si.fullName, si.contactPhone, si.email)))
   )
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/form/SubscriptionDataForm.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/form/SubscriptionDataForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/form/SubscriptionDataForm.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/form/SubscriptionDataForm.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.cbcrfrontend.form
 
 import play.api.data.Form
 import play.api.data.Forms.{mapping, text}
+import uk.gov.hmrc.cbcrfrontend.emailaddress.{EmailAddress, EmailAddressValidation}
 import uk.gov.hmrc.cbcrfrontend.model.SubscriberContact
-import uk.gov.hmrc.emailaddress.EmailAddress
 
 object SubscriptionDataForm {
   def condTrue(condition: Boolean, statement: Boolean): Boolean = if (condition) statement else true
@@ -38,9 +38,9 @@ object SubscriptionDataForm {
         .verifying("contactInfoSubscriber.emailAddress.error.empty", _.trim != "")
         .verifying(
           "contactInfoSubscriber.emailAddress.error.invalid",
-          x => condTrue(x.trim != "", EmailAddress.isValid(x))
+          x => condTrue(x.trim != "", new EmailAddressValidation().isValid(x))
         )
         .transform[EmailAddress](EmailAddress(_), _.value)
-    )(SubscriberContact.apply)(SubscriberContact.unapply)
+    )(SubscriberContact.apply)(SubscriberContact.unapply(_))
   )
 }

--- a/app/uk/gov/hmrc/cbcrfrontend/form/SurveyForm.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/form/SurveyForm.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/AgencyBusinessName.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/AgencyBusinessName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/BPRKnownFacts.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/BPRKnownFacts.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/BusinessMatchingModels.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/BusinessMatchingModels.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/CBCEnrolment.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/CBCEnrolment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/CBCRXMLFile.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/CBCRXMLFile.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/DatesOverlap.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/DatesOverlap.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/DocRefIdResponses.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/DocRefIdResponses.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/DocTypeIndic.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/DocTypeIndic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ETMPGetResponse.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ETMPGetResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ETMPGetResponse.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ETMPGetResponse.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.cbcrfrontend.model
 
 import play.api.libs.json.Reads._
 import play.api.libs.json._
-import uk.gov.hmrc.emailaddress.{EmailAddress, PlayJsonFormats}
+import uk.gov.hmrc.cbcrfrontend.emailaddress.{EmailAddress, PlayJsonFormats}
 
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -52,7 +52,7 @@ object PhoneNumber {
   }
 }
 
-case class ContactDetails(email: EmailAddress, phoneNumber: String)
+case class ContactDetails(email: String, phoneNumber: String)
 
 object ContactDetails {
   implicit val emailFormat: Format[EmailAddress] =

--- a/app/uk/gov/hmrc/cbcrfrontend/model/Email.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/Email.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/EnvelopeId.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/EnvelopeId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/EnvelopeRequest.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/EnvelopeRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ErrorTypes.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ErrorTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FieldName.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FieldName.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FileDetails.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FileDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FileId.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FileId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FileMetadata.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FileMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FileUploadCallbackResponse.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FileUploadCallbackResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FileUploadErrorTypes.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FileUploadErrorTypes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/FilingType.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/FilingType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/GGId.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/GGId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/Hash.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/Hash.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/MessageRefID.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/MessageRefID.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/MessageTypeIndic.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/MessageTypeIndic.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ParentGroupElement.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ParentGroupElement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/PartialReportingEntityData.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/PartialReportingEntityData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ReportingEntityData.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ReportingEntityData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ReportingEntityDataModel.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ReportingEntityDataModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/ReportingRole.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ReportingRole.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubmissionDate.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubmissionDate.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubmissionMetaData.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubmissionMetaData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubmitterInfo.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubmitterInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubmitterInfo.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubmitterInfo.scala
@@ -18,14 +18,12 @@ package uk.gov.hmrc.cbcrfrontend.model
 
 import play.api.libs.json._
 import uk.gov.hmrc.auth.core.AffinityGroup
-import uk.gov.hmrc.emailaddress.EmailAddress
-import uk.gov.hmrc.emailaddress.PlayJsonFormats._
 
 case class SubmitterInfo(
   fullName: String,
   agencyBusinessName: Option[AgencyBusinessName],
   contactPhone: String,
-  email: EmailAddress,
+  email: String,
   affinityGroup: Option[AffinityGroup]
 )
 
@@ -37,7 +35,7 @@ object SubmitterInfo {
           fullName <- m.get("fullName").flatMap(_.asOpt[String])
           abn      <- m.get("agencyBusinessName").map(_.asOpt[String])
           cp       <- m.get("contactPhone").flatMap(_.asOpt[String])
-          email    <- m.get("email").flatMap(_.asOpt[EmailAddress])
+          email    <- m.get("email").flatMap(_.asOpt[String])
           ag       <- m.get("affinityGroup").map(_.asOpt[AffinityGroup])
         } yield JsSuccess(SubmitterInfo(fullName, abn.map(AgencyBusinessName(_)), cp, email, ag))
         result.getOrElse(JsError(s"Unable to serialise $json as a  SubmitterInfo"))

--- a/app/uk/gov/hmrc/cbcrfrontend/model/Subscribed.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/Subscribed.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SubscriberContact.scala
@@ -25,7 +25,7 @@ import play.api.data.FormError
 import play.api.data.format.{Formats, Formatter}
 import play.api.libs.json._
 import uk.gov.hmrc.domain.Modulus23Check
-import uk.gov.hmrc.emailaddress.EmailAddress
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 
 /** A CBCId defined as at 15 digit reference using a modulus 23 check digit Digit 1 is an 'X' Digit 2 is the check digit
   * Digits 3-5 is the short name 'CBC' Digits 6-9 are '0000' Digits 10-15 are for the id sequence e.g. '000001' -

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SummaryData.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SummaryData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/SurveyAnswers.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/SurveyAnswers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/TIN.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/TIN.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/UltimateParentEntity.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/UltimateParentEntity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/UserIds.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/UserIds.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/Utr.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/Utr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/model/XMLInfo.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/XMLInfo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/package.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/repositories/CBCSessionCache.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/repositories/CBCSessionCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidator.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/CBCIdService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/CBCIdService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/CBCRXMLValidator.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/CBCRXMLValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/CreationDateService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/CreationDateService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/DocRefIdService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/DocRefIdService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/EmailService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/EmailService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/EnrolmentsService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/EnrolmentsService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/FileUploadService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/FileUploadService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/MessageRefIdService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/MessageRefIdService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/ReportingEntityDataService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/ReportingEntityDataService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/services/XmlInfoExtract.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/XmlInfoExtract.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/typesclasses/ServiceUrl.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/typesclasses/ServiceUrl.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/util/BusinessRulesUtil.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/util/BusinessRulesUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/util/ConfigurationOps.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/util/ConfigurationOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/util/ModifySize.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/util/ModifySize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/util/UUIDGenerator.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/util/UUIDGenerator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/Layout.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/Views.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/Views.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/csrf_token.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/csrf_token.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/error_template.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/error_template.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/notAuthorisedEnhancement.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/notAuthorisedEnhancement.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/not_authorised_assistant.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/not_authorised_assistant.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/not_authorised_individual.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/not_authorised_individual.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/shared/enterKnownFacts.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/shared/enterKnownFacts.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/shared/knownFactsNotFound.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/shared/knownFactsNotFound.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/shared/regenerate.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/shared/regenerate.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/shared/sessionExpired.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/shared/sessionExpired.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/start.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/start.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/enterCBCId.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/enterCBCId.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/enterCompanyName.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/enterCompanyName.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/chooseFile.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/chooseFile.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadError.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadError.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadProgress.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadProgress.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadResult.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/fileupload/fileUploadResult.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/notRegistered.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/notRegistered.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitInfoUltimateParentEntity.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitInfoUltimateParentEntity.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSuccessReceipt.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSuccessReceipt.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSummary.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSummary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSummary.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitSummary.scala.html
@@ -116,7 +116,7 @@
                     content = Text(messages("submitSummary.contactDetails.email"))
                 ),
                 value = Value(
-                    content = Text(summaryData.submissionMetaData.submitterInfo.email.value)
+                    content = Text(summaryData.submissionMetaData.submitterInfo.email)
                 ),
                 actions = Some(Actions(
                     items = Seq(

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitterInfo.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/submitterInfo.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/unregisteredGGAccount.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/unregisteredGGAccount.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/submission/utrCheck.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/submission/utrCheck.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/subscription/alreadySubscribed.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/subscription/alreadySubscribed.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/subscription/contactInfoSubscriber.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/subscription/contactInfoSubscriber.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/subscription/notAuthorised.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/subscription/notAuthorised.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/subscription/subscribeMatchFound.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/subscription/subscribeMatchFound.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/subscription/subscribeSuccessCbcId.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/subscription/subscribeSuccessCbcId.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/update/contactDetailsUpdated.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/update/contactDetailsUpdated.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/cbcrfrontend/views/update/updateContactInfoSubscriber.scala.html
+++ b/app/uk/gov/hmrc/cbcrfrontend/views/update/updateContactInfoSubscriber.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -28,7 +28,6 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"     %% s"hmrc-mongo-test-$playVersion" % hmrcMongoVersion     % scope,
     "org.mockito"           %% "mockito-scala"                 % mockitoScalaVersion  % scope,
     "org.mockito"           %% "mockito-scala-cats"            % mockitoScalaVersion  % scope,
-    "com.github.tomakehurst" % "wiremock"                      % "3.0.0-beta-7"       % scope,
     "xerces"                 % "xercesImpl"                    % "2.12.2"             % scope
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,6 @@ object AppDependencies {
     "uk.gov.hmrc"             %% s"bootstrap-frontend-$playVersion" % hmrcBootstrapVersion,
     "uk.gov.hmrc"             %% s"play-frontend-hmrc-$playVersion" % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo"       %% s"hmrc-mongo-$playVersion"         % hmrcMongoVersion,
-    "uk.gov.hmrc"             %% "emailaddress"                     % "3.7.0",
     "uk.gov.hmrc"             %% s"domain-$playVersion"             % "10.0.0",
     "org.typelevel"           %% "cats-core"                        % "2.12.0",
     "org.codehaus.woodstox"    % "stax2-api"                        % "4.2.2",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object AppDependencies {
   val hmrcBootstrapVersion = "8.5.0"
-  val mockitoScalaVersion = "1.17.31"
+  val mockitoScalaVersion = "1.17.37"
   val hmrcMongoVersion = "1.4.0"
   val playVersion = "play-30"
 
@@ -13,13 +13,13 @@ object AppDependencies {
     "uk.gov.hmrc"             %% s"play-frontend-hmrc-$playVersion" % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo"       %% s"hmrc-mongo-$playVersion"         % hmrcMongoVersion,
     "uk.gov.hmrc"             %% "emailaddress"                     % "3.7.0",
-    "uk.gov.hmrc"             %% s"domain-$playVersion"             % "9.0.0",
+    "uk.gov.hmrc"             %% s"domain-$playVersion"             % "10.0.0",
     "org.typelevel"           %% "cats-core"                        % "2.12.0",
-    "org.codehaus.woodstox"    % "stax2-api"                        % "3.1.4",
+    "org.codehaus.woodstox"    % "stax2-api"                        % "4.2.2",
     "org.codehaus.woodstox"    % "woodstox-core-asl"                % "4.4.1",
-    "commons-io"               % "commons-io"                       % "2.6",
+    "commons-io"               % "commons-io"                       % "2.16.1",
     "org.mindrot"              % "jbcrypt"                          % "0.4",
-    "com.sun.msv.datatype.xsd" % "xsdlib"                           % "2013.2",
+    "com.sun.msv.datatype.xsd" % "xsdlib"                           % "20060615",
     "msv"                      % "msv"                              % "20050913"
   )
 
@@ -29,6 +29,6 @@ object AppDependencies {
     "org.mockito"           %% "mockito-scala"                 % mockitoScalaVersion  % scope,
     "org.mockito"           %% "mockito-scala-cats"            % mockitoScalaVersion  % scope,
     "com.github.tomakehurst" % "wiremock"                      % "3.0.0-beta-7"       % scope,
-    "xerces"                 % "xercesImpl"                    % "2.12.0"             % scope
+    "xerces"                 % "xercesImpl"                    % "2.12.2"             % scope
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import sbt.*
 object AppDependencies {
   val hmrcBootstrapVersion = "8.5.0"
   val mockitoScalaVersion = "1.17.37"
-  val hmrcMongoVersion = "1.4.0"
+  val hmrcMongoVersion = "2.3.0"
   val playVersion = "play-30"
 
   val compile: Seq[ModuleID] = Seq(
@@ -18,7 +18,7 @@ object AppDependencies {
     "org.codehaus.woodstox"    % "woodstox-core-asl"                % "4.4.1",
     "commons-io"               % "commons-io"                       % "2.16.1",
     "org.mindrot"              % "jbcrypt"                          % "0.4",
-    "com.sun.msv.datatype.xsd" % "xsdlib"                           % "20060615",
+    "com.sun.msv.datatype.xsd" % "xsdlib"                           % "2013.2",
     "msv"                      % "msv"                              % "20050913"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import play.sbt.PlayImport.ws
 import sbt.*
 
 object AppDependencies {
-  val hmrcBootstrapVersion = "8.3.0"
+  val hmrcBootstrapVersion = "8.5.0"
   val mockitoScalaVersion = "1.17.31"
   val hmrcMongoVersion = "1.4.0"
   val playVersion = "play-30"
@@ -10,7 +10,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     ws,
     "uk.gov.hmrc"             %% s"bootstrap-frontend-$playVersion" % hmrcBootstrapVersion,
-    "uk.gov.hmrc"             %% s"play-frontend-hmrc-$playVersion" % "8.3.0",
+    "uk.gov.hmrc"             %% s"play-frontend-hmrc-$playVersion" % hmrcBootstrapVersion,
     "uk.gov.hmrc.mongo"       %% s"hmrc-mongo-$playVersion"         % hmrcMongoVersion,
     "uk.gov.hmrc"             %% "emailaddress"                     % "3.7.0",
     "uk.gov.hmrc"             %% s"domain-$playVersion"             % "9.0.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,7 +14,7 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"       %% s"hmrc-mongo-$playVersion"         % hmrcMongoVersion,
     "uk.gov.hmrc"             %% "emailaddress"                     % "3.7.0",
     "uk.gov.hmrc"             %% s"domain-$playVersion"             % "9.0.0",
-    "org.typelevel"           %% "cats-core"                        % "2.0.0",
+    "org.typelevel"           %% "cats-core"                        % "2.12.0",
     "org.codehaus.woodstox"    % "stax2-api"                        % "3.1.4",
     "org.codehaus.woodstox"    % "woodstox-core-asl"                % "4.4.1",
     "commons-io"               % "commons-io"                       % "2.6",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"        % "3.22.0")
+addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"        % "3.23.0")
 
 addSbtPlugin("uk.gov.hmrc"        %% "sbt-distributables"    % "2.5.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"        % "3.22.0")
 
 addSbtPlugin("uk.gov.hmrc"        %% "sbt-distributables"    % "2.5.0")
 
-addSbtPlugin("org.playframework"  %% "sbt-plugin"            % "3.0.2")
+addSbtPlugin("org.playframework"  %% "sbt-plugin"            % "3.0.5")
 
 addSbtPlugin("org.scoverage"      %% "sbt-scoverage"         % "2.0.9")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"        % "3.23.0")
+addSbtPlugin("uk.gov.hmrc"        %% "sbt-auto-build"        % "3.24.0")
 
 addSbtPlugin("uk.gov.hmrc"        %% "sbt-distributables"    % "2.5.0")
 

--- a/test/resources/fakeConfig.conf
+++ b/test/resources/fakeConfig.conf
@@ -1,4 +1,4 @@
-# Copyright 2023 HM Revenue & Customs
+# Copyright 2024 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/auth/AuthRedirectsExternalSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/auth/AuthRedirectsExternalSpec.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cbcrfrontend.auth
+
+import java.io.File
+
+import play.api.http.HeaderNames
+import play.api.mvc.Result
+import play.api.{Configuration, Environment, Mode}
+import play.test.WithApplication
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class AuthRedirectsExternalSpec extends AnyWordSpec with ScalaFutures with Matchers {
+
+  trait Dev {
+    val mode = Mode.Dev
+  }
+
+  trait Prod {
+    val mode = Mode.Prod
+  }
+
+  trait BaseUri {
+    val strideService = "http://localhost:9041"
+    val stridePath = "/stride/sign-in"
+  }
+
+  trait Setup extends WithApplication with BaseUri {
+
+    def mode: Mode
+
+    def extraConfig: Map[String, Any] = Map()
+
+    trait TestRedirects extends AuthRedirectsExternal {
+
+      val env = Environment(new File("."), getClass.getClassLoader, mode)
+
+      val config = Configuration.from(
+        Map(
+          "appName"  -> "app",
+          "run.mode" -> mode.toString
+        ) ++ extraConfig
+      )
+    }
+
+    object Redirect extends TestRedirects
+
+    def validate(redirect: Result)(expectedLocation: String): Unit = {
+      redirect.header.status shouldBe 303
+      redirect.header.headers(HeaderNames.LOCATION) shouldBe expectedLocation
+    }
+  }
+
+  "redirect with defaults from config" should {
+
+    "redirect to stride auth in Dev without failureURL" in new Setup with Dev {
+      validate(Redirect.toStrideLogin("/success"))(
+        expectedLocation = s"$strideService$stridePath?successURL=%2Fsuccess&origin=app"
+      )
+    }
+
+    "redirect to stride auth in Dev with failureURL" in new Setup with Dev {
+      validate(Redirect.toStrideLogin("/success", Some("/failure")))(
+        expectedLocation = s"$strideService$stridePath?successURL=%2Fsuccess&origin=app&failureURL=%2Ffailure"
+      )
+    }
+
+    "redirect to stride auth in Prod without failureURL" in new Setup with Prod {
+      validate(Redirect.toStrideLogin("/success"))(expectedLocation = s"$stridePath?successURL=%2Fsuccess&origin=app")
+    }
+
+    "redirect to stride auth in Prod with failureURL" in new Setup with Prod {
+      validate(Redirect.toStrideLogin("/success", Some("/failure")))(
+        expectedLocation = s"$stridePath?successURL=%2Fsuccess&origin=app&failureURL=%2Ffailure"
+      )
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/connectors/FileUploadServiceConnectorSpec.scala
@@ -30,8 +30,8 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{Json, OFormat}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.auth.core.AffinityGroup.Individual
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model._
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/CBCEnhancementsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/CBCEnhancementsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/CSRFTest.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/CSRFTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/EnrolControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/EnrolControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/FileUploadControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SharedControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SharedControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SharedControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SharedControllerSpec.scala
@@ -33,11 +33,11 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, header, status}
 import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector}
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.repositories.CBCSessionCache
 import uk.gov.hmrc.cbcrfrontend.services._
 import uk.gov.hmrc.cbcrfrontend.views.Views
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/StartControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubmissionSpec.scala
@@ -37,12 +37,12 @@ import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector}
 import uk.gov.hmrc.cbcrfrontend._
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.form.SubmitterInfoForm
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.repositories.CBCSessionCache
 import uk.gov.hmrc.cbcrfrontend.services._
 import uk.gov.hmrc.cbcrfrontend.views.Views
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
@@ -36,11 +36,11 @@ import play.api.test.Helpers.{await, call, contentAsString, defaultAwaitTimeout,
 import uk.gov.hmrc.auth.core.retrieve.Credentials
 import uk.gov.hmrc.auth.core.{AffinityGroup, AuthConnector}
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.repositories.CBCSessionCache
 import uk.gov.hmrc.cbcrfrontend.services._
 import uk.gov.hmrc.cbcrfrontend.views.Views
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.mongo.cache.CacheItem
 import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
 

--- a/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/controllers/SubscriptionControllerSpec.scala
@@ -497,7 +497,7 @@ class SubscriptionControllerSpec
       val result = await(controller.getUpdateInfoSubscriber()(fakeRequest))
 
       result.header.status shouldEqual Status.SEE_OTHER
-      result.header.headers shouldEqual Map("Location" -> routes.SharedController.contactDetailsError.url)
+      result.header.headers.toMap shouldEqual Map("Location" -> routes.SharedController.contactDetailsError.url)
     }
 
     "return OK otherwise" in {

--- a/test/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/BPRKnownFactsServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidatorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidatorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCBusinessRuleValidatorSpec.scala
@@ -27,10 +27,10 @@ import org.scalatest.wordspec.AnyWordSpec
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model.DocRefIdResponses.{DoesNotExist, Invalid, Valid}
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.repositories.CBCSessionCache
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.io.File

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCIdServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCIdServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCIdServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCIdServiceSpec.scala
@@ -27,8 +27,8 @@ import play.api.http.Status
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.cbcrfrontend.connectors.CBCRBackendConnector
 import uk.gov.hmrc.cbcrfrontend.controllers.CSRFTest
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model.{ContactDetails, ContactName, ETMPSubscription, EtmpAddress}
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCSessionCacheSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCSessionCacheSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CBCXMLValidatorSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CBCXMLValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/CreationDateSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/CreationDateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/DocRefIdServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/DocRefIdServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/FileUploadServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/FileUploadServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/FileUploadServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/FileUploadServiceSpec.scala
@@ -29,9 +29,9 @@ import play.api.test.Helpers.{LOCATION, await, defaultAwaitTimeout}
 import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 import uk.gov.hmrc.cbcrfrontend.config.FrontendAppConfig
 import uk.gov.hmrc.cbcrfrontend.connectors.{CBCRBackendConnector, FileUploadServiceConnector}
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.util.UUIDGenerator
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 

--- a/test/uk/gov/hmrc/cbcrfrontend/services/GuiceConfigSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/GuiceConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/ReportingEntityDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/ReportingEntityDataServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataServiceSpec.scala
@@ -27,9 +27,9 @@ import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.api.{Application, Configuration}
 import uk.gov.hmrc.cbcrfrontend.controllers.CSRFTest
+import uk.gov.hmrc.cbcrfrontend.emailaddress.EmailAddress
 import uk.gov.hmrc.cbcrfrontend.model._
 import uk.gov.hmrc.cbcrfrontend.util.WireMockMethods
-import uk.gov.hmrc.emailaddress.EmailAddress
 import uk.gov.hmrc.http.test.WireMockSupport
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig

--- a/test/uk/gov/hmrc/cbcrfrontend/services/WithConfigFakeApplication.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/WithConfigFakeApplication.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/XmlErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/XmlErrorHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/services/XmlInfoExtractSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/services/XmlInfoExtractSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/cbcrfrontend/util/BusinessRulesUtilSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/util/BusinessRulesUtilSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2024 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
### **HANDOVER:**

**Helpful links:**

- Our previous PR addressing the same issue for CBCR: https://github.com/hmrc/cbcr/pull/245/files#diff-2c8333f42986702f0da9104f540f6f70497eb4d5e3453b13559e7a6986e3cc39
- Our previous PR addressing the same issue for CBCR-STUBS: https://jira.tools.tax.service.gov.uk/browse/DLS-10865 (divided to two PRs) 

**Make sure that you have:**

- [ ] addressed the BOT suggestion - that requires Java 17 so maybe we need to discuss that with the team
- [ ] run the ATs and they all passed (bear in mind the intermittent failures that we know of)


===========================

Additonal info:

### **| Documentation for the addition of AuthRedirectsExternal file |**

_Background:_

With the upgrade of bootstrap to 8.4.0. the AuthRedirects.scala stopped being a member of the bootstrap.config. Below is a brief piece of the error that I received

object AuthRedirects is not a member of package uk.gov.hmrc.play.bootstrap.config
[error] import uk.gov.hmrc.play.bootstrap.config.AuthRedirects
not found: type AuthRedirects

We have experienced that in the past, see here: https://hmrcdigital.slack.com/archives/C03D5C9F6RX/p1708699179674479

_Solution:_

To address that issue the AuthRedirectsExternal.scala file has been added under [DLS-10863](https://jira.tools.tax.service.gov.uk/browse/DLS-10863). The contents of the file were copied from the old version of the bootstrap library.
See the source: https://github.com/hmrc/bootstrap-play/blob/main/bootstrap-common-play-28/src/main/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirects.scala

Later on I've added the file test/uk/gov/hmrc/cbcrfrontend/auth/AuthRedirectsExternalSpec.scala with the tests for the content of AuthRedirectsExternal.scala.

The source for the contents implemented in AuthRedirectsExternal.scala. can be found here:
https://github.com/hmrc/bootstrap-play/blob/main/bootstrap-common-play-28/src/test/scala/uk/gov/hmrc/play/bootstrap/config/AuthRedirectsSpec.scala

==========

Note for myself:
https://github.com/hmrc/help-to-save-stride-frontend/pull/226

==============