### PR TITLE
DLS-11286 | Add additional logging for invalid cbcid

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/model/ErrorTypes.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/model/ErrorTypes.scala
@@ -30,6 +30,7 @@ object CBCErrors {
     case v: ValidationErrors          => v.show
     case InvalidSession               => InvalidSession.toString
     case ExpiredSession(msg)          => msg
+    case error: CBCErrors             => error.toString
   }
 }
 

--- a/app/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataService.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/services/SubscriptionDataService.scala
@@ -61,9 +61,11 @@ class SubscriptionDataService @Inject() (http: HttpClient, servicesConfig: Servi
                   errors => Left[CBCErrors, Option[SubscriptionDetails]](UnexpectedState(errors.mkString)),
                   details => Right[CBCErrors, Option[SubscriptionDetails]](Some(details))
                 )
-            case Status.NOT_FOUND =>
-              Right(None)
-            case s => Left(UnexpectedState(s"Call to RetrieveSubscription failed - backend returned $s"))
+            case Status.NOT_FOUND => Right(None)
+            case s =>
+              val message = s"Call to RetrieveSubscription failed - backend returned $s"
+              logger.warn(message)
+              Left(UnexpectedState(message))
           }
         }
         .recover { case NonFatal(t) =>


### PR DESCRIPTION
Business validation errors reported are at times hard to trace due to no details on the reason being logged. For ex, the issue of **SendingEntityError**, it would be good to know if it's validation failure resulting from missing data in source xml or backend lookup failure.