### PR TITLE
DLS-11514 | Fix build failure due to wrong test fixture for future date failure scenario

### DIFF
--- a/app/uk/gov/hmrc/cbcrfrontend/CBCRErrorHandler.scala
+++ b/app/uk/gov/hmrc/cbcrfrontend/CBCRErrorHandler.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.cbcrfrontend
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import play.api.{Configuration, Environment}
-import play.twirl.api.{Html, HtmlFormat}
+import play.twirl.api.Html
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.cbcrfrontend.auth.AuthRedirectsExternal
 import uk.gov.hmrc.cbcrfrontend.controllers.routes

--- a/test/resources/cbcr-invalidReportingDates1.xml
+++ b/test/resources/cbcr-invalidReportingDates1.xml
@@ -27,7 +27,7 @@
             </ns1:Entity>
             <ns1:ReportingRole>CBC703</ns1:ReportingRole>
             <ns1:ReportingPeriod>
-                <ns1:StartDate>2025-04-10</ns1:StartDate>
+                <ns1:StartDate>2035-04-10</ns1:StartDate>
                 <ns1:EndDate>2016-03-31</ns1:EndDate>
             </ns1:ReportingPeriod>
             <ns1:DocSpec>


### PR DESCRIPTION
- Pushing it out by few years. Ideal thing would've been to look at templating these, but, with the upcoming CBCR changes this is not an effort worth investing in now.