### PR TITLE
DLS-12660 | Update test fixture constraint and email test domain

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -99,7 +99,7 @@ Prod {
   default-creation-date {
     day = 23
     month = 12
-    year = 2022
+    year = 2023
   }
 }
 

--- a/test/uk/gov/hmrc/cbcrfrontend/emailaddress/EmailAddressSpec.scala
+++ b/test/uk/gov/hmrc/cbcrfrontend/emailaddress/EmailAddressSpec.scala
@@ -39,8 +39,8 @@ class EmailAddressSpec extends AnyWordSpec with GuiceOneAppPerSuite with Matcher
     val validation = new EmailAddressValidation(appConfig)
 
     "validate a correct email address" in {
-      validation.isValid("user@test.com") shouldBe true
-      validation.isValid("user@test.co.uk") shouldBe true
+      validation.isValid("user@example.com") shouldBe true
+      validation.isValid("user@example.co.uk") shouldBe true
     }
     "validate invalid email" in {
       validation.isValid("a@a") shouldBe false


### PR DESCRIPTION
- Adjust creation date for test fixtures. Tried inlining this into ATs but is far bigger change and needs change in xml data extraction and validation logic in frontend
- test.com domain seems to be missing MX records now as a result the assumption of using that to verify emails has started to fail. Changed to another domain that still has the MX records available.